### PR TITLE
Data model availability

### DIFF
--- a/app/src/main/java/ch/epfl/skysync/database/MockDatabase.kt
+++ b/app/src/main/java/ch/epfl/skysync/database/MockDatabase.kt
@@ -8,6 +8,10 @@ class MockDatabase : Database {
   private var idCounter = 0
   private var state = hashMapOf<String, Any>()
 
+    fun getState(): HashMap<String, Any> {
+        return state
+    }
+
   private fun getKey(path: String, id: String): String {
     return "$path/$id"
   }
@@ -21,7 +25,7 @@ class MockDatabase : Database {
     val key = getKey(path, idCounter.toString())
     state[key] = item
     idCounter += 1
-    onCompletion
+    onCompletion()
   }
 
   override fun <T : Any> get(

--- a/app/src/main/java/ch/epfl/skysync/database/MockDatabase.kt
+++ b/app/src/main/java/ch/epfl/skysync/database/MockDatabase.kt
@@ -8,9 +8,9 @@ class MockDatabase : Database {
   private var idCounter = 0
   private var state = hashMapOf<String, Any>()
 
-    fun getState(): HashMap<String, Any> {
-        return state
-    }
+  fun getState(): HashMap<String, Any> {
+    return state
+  }
 
   private fun getKey(path: String, id: String): String {
     return "$path/$id"

--- a/app/src/main/java/ch/epfl/skysync/database/Schema.kt
+++ b/app/src/main/java/ch/epfl/skysync/database/Schema.kt
@@ -1,0 +1,19 @@
+package ch.epfl.skysync.database
+
+/** Implemented by schema classes that can be casted to a model class. */
+interface SchemaDecode<Model> {
+  /** Create a new instance of the `Model` class derived from this schema instance */
+  fun toModel(): Model
+}
+
+/**
+ * Implemented by the companion object of schema classes for which an instance can be constructed
+ * from a model.
+ *
+ * This is done this way as kotlin does not support static functions in interfaces:
+ * https://stackoverflow.com/questions/40370471/is-it-possible-to-specify-a-static-function-in-a-kotlin-interface
+ */
+interface SchemaEncode<Model, Schema> {
+  /** Create a new instance of the `Schema` class derived from the given `Model` instance */
+  fun fromModel(model: Model): Schema
+}

--- a/app/src/main/java/ch/epfl/skysync/database/Schema.kt
+++ b/app/src/main/java/ch/epfl/skysync/database/Schema.kt
@@ -1,19 +1,7 @@
 package ch.epfl.skysync.database
 
 /** Implemented by schema classes that can be casted to a model class. */
-interface SchemaDecode<Model> {
+interface Schema<Model> {
   /** Create a new instance of the `Model` class derived from this schema instance */
   fun toModel(): Model
-}
-
-/**
- * Implemented by the companion object of schema classes for which an instance can be constructed
- * from a model.
- *
- * This is done this way as kotlin does not support static functions in interfaces:
- * https://stackoverflow.com/questions/40370471/is-it-possible-to-specify-a-static-function-in-a-kotlin-interface
- */
-interface SchemaEncode<Model, Schema> {
-  /** Create a new instance of the `Schema` class derived from the given `Model` instance */
-  fun fromModel(model: Model): Schema
 }

--- a/app/src/main/java/ch/epfl/skysync/database/schemas/AvailabilitySchema.kt
+++ b/app/src/main/java/ch/epfl/skysync/database/schemas/AvailabilitySchema.kt
@@ -1,0 +1,34 @@
+package ch.epfl.skysync.database.schemas
+
+import ch.epfl.skysync.database.SchemaDecode
+import ch.epfl.skysync.database.SchemaEncode
+import ch.epfl.skysync.model.Availability
+import com.google.firebase.firestore.DocumentId
+import java.util.Date
+
+data class AvailabilitySchema(
+    @DocumentId val id: String? = null,
+    val personId: String? = null,
+    val from: Date? = null,
+    val to: Date? = null
+) : SchemaDecode<Availability> {
+  override fun toModel(): Availability {
+    return Availability(
+        id!!,
+        personId!!,
+        from!!,
+        to!!,
+    )
+  }
+
+  companion object : SchemaEncode<Availability, AvailabilitySchema> {
+    override fun fromModel(model: Availability): AvailabilitySchema {
+      return AvailabilitySchema(
+          model.id,
+          model.personId,
+          model.from,
+          model.to,
+      )
+    }
+  }
+}

--- a/app/src/main/java/ch/epfl/skysync/database/schemas/AvailabilitySchema.kt
+++ b/app/src/main/java/ch/epfl/skysync/database/schemas/AvailabilitySchema.kt
@@ -3,34 +3,40 @@ package ch.epfl.skysync.database.schemas
 import ch.epfl.skysync.database.Schema
 import ch.epfl.skysync.model.Availability
 import ch.epfl.skysync.model.AvailabilityStatus
+import ch.epfl.skysync.model.TimeSlot
 import com.google.firebase.firestore.DocumentId
+import java.time.ZoneOffset
 import java.util.Date
 
 data class AvailabilitySchema(
     @DocumentId val id: String? = null,
     val personId: String? = null,
     val status: AvailabilityStatus? = null,
-    val from: Date? = null,
-    val to: Date? = null
+    val timeSlot: TimeSlot? = null,
+    // We use the Date class instead of the LocalDate one because
+    // firestore store LocalDate as a collection of fields
+    // whereas it stores Date as a string, which is simpler
+    // and will lead to easier queries
+    val date: Date? = null
 ) : Schema<Availability> {
-  override fun toModel(): Availability {
-    return Availability(
-        id!!,
-        status!!,
-        from!!,
-        to!!,
-    )
-  }
-
-  companion object {
-    fun fromModel(personId: String, model: Availability): AvailabilitySchema {
-      return AvailabilitySchema(
-          model.id,
-          personId,
-          model.status,
-          model.from,
-          model.to,
-      )
+    override fun toModel(): Availability {
+        return Availability(
+            id!!,
+            status!!,
+            timeSlot!!,
+            (date!!).toInstant().atZone(ZoneOffset.systemDefault()).toLocalDate(),
+        )
     }
-  }
+
+    companion object {
+        fun fromModel(personId: String, model: Availability): AvailabilitySchema {
+            return AvailabilitySchema(
+                model.id,
+                personId,
+                model.status,
+                model.timeSlot,
+                Date.from(model.date.atStartOfDay(ZoneOffset.UTC).toInstant()),
+            )
+        }
+    }
 }

--- a/app/src/main/java/ch/epfl/skysync/database/schemas/AvailabilitySchema.kt
+++ b/app/src/main/java/ch/epfl/skysync/database/schemas/AvailabilitySchema.kt
@@ -1,31 +1,33 @@
 package ch.epfl.skysync.database.schemas
 
-import ch.epfl.skysync.database.SchemaDecode
-import ch.epfl.skysync.database.SchemaEncode
+import ch.epfl.skysync.database.Schema
 import ch.epfl.skysync.model.Availability
+import ch.epfl.skysync.model.AvailabilityStatus
 import com.google.firebase.firestore.DocumentId
 import java.util.Date
 
 data class AvailabilitySchema(
     @DocumentId val id: String? = null,
     val personId: String? = null,
+    val status: AvailabilityStatus? = null,
     val from: Date? = null,
     val to: Date? = null
-) : SchemaDecode<Availability> {
+) : Schema<Availability> {
   override fun toModel(): Availability {
     return Availability(
         id!!,
-        personId!!,
+        status!!,
         from!!,
         to!!,
     )
   }
 
-  companion object : SchemaEncode<Availability, AvailabilitySchema> {
-    override fun fromModel(model: Availability): AvailabilitySchema {
+  companion object {
+    fun fromModel(personId: String, model: Availability): AvailabilitySchema {
       return AvailabilitySchema(
           model.id,
-          model.personId,
+          personId,
+          model.status,
           model.from,
           model.to,
       )

--- a/app/src/main/java/ch/epfl/skysync/database/schemas/AvailabilitySchema.kt
+++ b/app/src/main/java/ch/epfl/skysync/database/schemas/AvailabilitySchema.kt
@@ -19,24 +19,24 @@ data class AvailabilitySchema(
     // and will lead to easier queries
     val date: Date? = null
 ) : Schema<Availability> {
-    override fun toModel(): Availability {
-        return Availability(
-            id!!,
-            status!!,
-            timeSlot!!,
-            (date!!).toInstant().atZone(ZoneOffset.systemDefault()).toLocalDate(),
-        )
-    }
+  override fun toModel(): Availability {
+    return Availability(
+        id!!,
+        status!!,
+        timeSlot!!,
+        (date!!).toInstant().atZone(ZoneOffset.systemDefault()).toLocalDate(),
+    )
+  }
 
-    companion object {
-        fun fromModel(personId: String, model: Availability): AvailabilitySchema {
-            return AvailabilitySchema(
-                model.id,
-                personId,
-                model.status,
-                model.timeSlot,
-                Date.from(model.date.atStartOfDay(ZoneOffset.UTC).toInstant()),
-            )
-        }
+  companion object {
+    fun fromModel(personId: String, model: Availability): AvailabilitySchema {
+      return AvailabilitySchema(
+          model.id,
+          personId,
+          model.status,
+          model.timeSlot,
+          Date.from(model.date.atStartOfDay(ZoneOffset.UTC).toInstant()),
+      )
     }
+  }
 }

--- a/app/src/main/java/ch/epfl/skysync/database/tables/AvailabilityTable.kt
+++ b/app/src/main/java/ch/epfl/skysync/database/tables/AvailabilityTable.kt
@@ -1,0 +1,37 @@
+package ch.epfl.skysync.database.tables
+
+import ch.epfl.skysync.database.Database
+import ch.epfl.skysync.database.schemas.AvailabilitySchema
+import ch.epfl.skysync.model.Availability
+
+/** Represent the "availability" table */
+class AvailabilityTable(private val db: Database) {
+
+  /**
+   * Get an availability by ID
+   *
+   * @param id The id of the availability
+   * @param onCompletion Callback called on completion of the operation
+   * @param onError Callback called when an error occurs
+   */
+  fun get(id: String, onCompletion: (Availability?) -> Unit, onError: (Exception) -> Unit) {
+    db.get(PATH, id, AvailabilitySchema::class, { onCompletion(it?.toModel()) }, onError)
+  }
+
+  /**
+   * Add a new availability to the database
+   *
+   * This will generate a new id for this availability and override any previously set id.
+   *
+   * @param item The availability to add to the database
+   * @param onCompletion Callback called on completion of the operation
+   * @param onError Callback called when an error occurs
+   */
+  fun add(item: Availability, onCompletion: () -> Unit, onError: (Exception) -> Unit) {
+    db.add(PATH, AvailabilitySchema.fromModel(item), { onCompletion() }, onError)
+  }
+
+  companion object {
+    const val PATH = "availability"
+  }
+}

--- a/app/src/main/java/ch/epfl/skysync/database/tables/AvailabilityTable.kt
+++ b/app/src/main/java/ch/epfl/skysync/database/tables/AvailabilityTable.kt
@@ -23,12 +23,18 @@ class AvailabilityTable(private val db: Database) {
    *
    * This will generate a new id for this availability and override any previously set id.
    *
+   * @param personId The ID of the person whose availability it is
    * @param item The availability to add to the database
    * @param onCompletion Callback called on completion of the operation
    * @param onError Callback called when an error occurs
    */
-  fun add(item: Availability, onCompletion: () -> Unit, onError: (Exception) -> Unit) {
-    db.add(PATH, AvailabilitySchema.fromModel(item), { onCompletion() }, onError)
+  fun add(
+      personId: String,
+      item: Availability,
+      onCompletion: () -> Unit,
+      onError: (Exception) -> Unit
+  ) {
+    db.add(PATH, AvailabilitySchema.fromModel(personId, item), { onCompletion() }, onError)
   }
 
   companion object {

--- a/app/src/main/java/ch/epfl/skysync/model/Availability.kt
+++ b/app/src/main/java/ch/epfl/skysync/model/Availability.kt
@@ -1,0 +1,11 @@
+package ch.epfl.skysync.model
+
+import java.util.Date
+
+/** Represent the availability of a person for some period */
+data class Availability(
+    val id: String = UNSET_ID,
+    val personId: String,
+    val from: Date,
+    val to: Date
+)

--- a/app/src/main/java/ch/epfl/skysync/model/Availability.kt
+++ b/app/src/main/java/ch/epfl/skysync/model/Availability.kt
@@ -5,7 +5,7 @@ import java.util.Date
 /** Represent the availability of a person for some period */
 data class Availability(
     val id: String = UNSET_ID,
-    val personId: String,
+    val status: AvailabilityStatus,
     val from: Date,
     val to: Date
 )

--- a/app/src/main/java/ch/epfl/skysync/model/Availability.kt
+++ b/app/src/main/java/ch/epfl/skysync/model/Availability.kt
@@ -1,11 +1,11 @@
 package ch.epfl.skysync.model
 
-import java.util.Date
+import java.time.LocalDate
 
 /** Represent the availability of a person for some period */
 data class Availability(
     val id: String = UNSET_ID,
     val status: AvailabilityStatus,
-    val from: Date,
-    val to: Date
+    val timeSlot: TimeSlot,
+    val date: LocalDate
 )

--- a/app/src/main/java/ch/epfl/skysync/model/AvailabilityStatus.kt
+++ b/app/src/main/java/ch/epfl/skysync/model/AvailabilityStatus.kt
@@ -1,0 +1,11 @@
+package ch.epfl.skysync.model
+
+/**
+ * Represent three statuses: "OK" for available, "MAYBE" for pending confirmation, and "NO" for not
+ * available
+ */
+enum class AvailabilityStatus {
+  OK,
+  MAYBE,
+  NO
+}

--- a/app/src/main/java/ch/epfl/skysync/model/TimeSlot.kt
+++ b/app/src/main/java/ch/epfl/skysync/model/TimeSlot.kt
@@ -1,0 +1,8 @@
+package ch.epfl.skysync.model
+
+/**
+ * Represent the day in two time slots, morning (AM) and afternoon (PM)
+ */
+enum class TimeSlot {
+    AM, PM
+}

--- a/app/src/main/java/ch/epfl/skysync/model/TimeSlot.kt
+++ b/app/src/main/java/ch/epfl/skysync/model/TimeSlot.kt
@@ -1,8 +1,7 @@
 package ch.epfl.skysync.model
 
-/**
- * Represent the day in two time slots, morning (AM) and afternoon (PM)
- */
+/** Represent the day in two time slots, morning (AM) and afternoon (PM) */
 enum class TimeSlot {
-    AM, PM
+  AM,
+  PM
 }

--- a/app/src/main/java/ch/epfl/skysync/model/UnsetId.kt
+++ b/app/src/main/java/ch/epfl/skysync/model/UnsetId.kt
@@ -1,0 +1,14 @@
+package ch.epfl.skysync.model
+
+// Only define a global constant to be used as default value for models id field
+// when creating a new instance of the model in the database.
+// Do not opt for a hierarchical data class pattern with an parent `IdentifiableModel` class
+// as kotlin doesn't support inheritance in data class well:
+// https://stackoverflow.com/questions/26444145/extend-data-class-in-kotlin
+
+/**
+ * Used for an ID that has not yet been generated
+ *
+ * This should only be used when adding a new item to a database.
+ */
+const val UNSET_ID = "__unset_id__"

--- a/app/src/test/java/ch/epfl/skysync/database/schemas/AvailabilityUnitTest.kt
+++ b/app/src/test/java/ch/epfl/skysync/database/schemas/AvailabilityUnitTest.kt
@@ -1,0 +1,40 @@
+package ch.epfl.skysync.database.schemas
+
+import ch.epfl.skysync.model.Availability
+import ch.epfl.skysync.model.AvailabilityStatus
+import ch.epfl.skysync.model.TimeSlot
+import org.junit.Test
+import org.junit.Assert.*
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.Date
+
+class AvailabilityUnitTest {
+
+    /**
+     * Test that both the casting from the schema format to the model format
+     * and from the model format to the schema format work.
+     */
+    @Test
+    fun modelSchemaCastingTest() {
+        val personId = "personId"
+        val localDate = LocalDate.now()
+        val date = Date.from(localDate.atStartOfDay(ZoneOffset.UTC).toInstant())
+        val availabilitySchema = AvailabilitySchema(
+            id="id",
+            personId = personId,
+            status = AvailabilityStatus.MAYBE,
+            timeSlot = TimeSlot.PM,
+            date=date
+        )
+        val availability = Availability(
+            id="id",
+            status = AvailabilityStatus.MAYBE,
+            timeSlot = TimeSlot.PM,
+            date=localDate
+        )
+
+        assertEquals(availability, availabilitySchema.toModel())
+        assertEquals(availabilitySchema, AvailabilitySchema.fromModel(personId, availability))
+    }
+}

--- a/app/src/test/java/ch/epfl/skysync/database/schemas/AvailabilityUnitTest.kt
+++ b/app/src/test/java/ch/epfl/skysync/database/schemas/AvailabilityUnitTest.kt
@@ -3,38 +3,35 @@ package ch.epfl.skysync.database.schemas
 import ch.epfl.skysync.model.Availability
 import ch.epfl.skysync.model.AvailabilityStatus
 import ch.epfl.skysync.model.TimeSlot
-import org.junit.Test
-import org.junit.Assert.*
 import java.time.LocalDate
 import java.time.ZoneOffset
 import java.util.Date
+import org.junit.Assert.*
+import org.junit.Test
 
 class AvailabilityUnitTest {
 
-    /**
-     * Test that both the casting from the schema format to the model format
-     * and from the model format to the schema format work.
-     */
-    @Test
-    fun modelSchemaCastingTest() {
-        val personId = "personId"
-        val localDate = LocalDate.now()
-        val date = Date.from(localDate.atStartOfDay(ZoneOffset.UTC).toInstant())
-        val availabilitySchema = AvailabilitySchema(
-            id="id",
+  /**
+   * Test that both the casting from the schema format to the model format and from the model format
+   * to the schema format work.
+   */
+  @Test
+  fun modelSchemaCastingTest() {
+    val personId = "personId"
+    val localDate = LocalDate.now()
+    val date = Date.from(localDate.atStartOfDay(ZoneOffset.UTC).toInstant())
+    val availabilitySchema =
+        AvailabilitySchema(
+            id = "id",
             personId = personId,
             status = AvailabilityStatus.MAYBE,
             timeSlot = TimeSlot.PM,
-            date=date
-        )
-        val availability = Availability(
-            id="id",
-            status = AvailabilityStatus.MAYBE,
-            timeSlot = TimeSlot.PM,
-            date=localDate
-        )
+            date = date)
+    val availability =
+        Availability(
+            id = "id", status = AvailabilityStatus.MAYBE, timeSlot = TimeSlot.PM, date = localDate)
 
-        assertEquals(availability, availabilitySchema.toModel())
-        assertEquals(availabilitySchema, AvailabilitySchema.fromModel(personId, availability))
-    }
+    assertEquals(availability, availabilitySchema.toModel())
+    assertEquals(availabilitySchema, AvailabilitySchema.fromModel(personId, availability))
+  }
 }

--- a/app/src/test/java/ch/epfl/skysync/database/tables/AvailabilityTableUnitTest.kt
+++ b/app/src/test/java/ch/epfl/skysync/database/tables/AvailabilityTableUnitTest.kt
@@ -5,58 +5,64 @@ import ch.epfl.skysync.database.schemas.AvailabilitySchema
 import ch.epfl.skysync.model.Availability
 import ch.epfl.skysync.model.AvailabilityStatus
 import ch.epfl.skysync.model.TimeSlot
-import org.junit.Test
-import org.junit.Assert.*
 import java.time.LocalDate
+import org.junit.Assert.*
+import org.junit.Test
 
 class AvailabilityTableUnitTest {
 
-    @Test
-    fun getTest() {
-        val id = "id-1"
-        val personId = "personId"
-        val availability = Availability(
+  @Test
+  fun getTest() {
+    val id = "id-1"
+    val personId = "personId"
+    val availability =
+        Availability(
             id = id,
             status = AvailabilityStatus.MAYBE,
             timeSlot = TimeSlot.PM,
-            date = LocalDate.now()
-        )
-        val db = MockDatabase()
-        val path = "${AvailabilityTable.PATH}/$id"
+            date = LocalDate.now())
+    val db = MockDatabase()
+    val path = "${AvailabilityTable.PATH}/$id"
 
-        // first manually put a AvailabilitySchema instance in the db
-        db.getState()[path] = AvailabilitySchema.fromModel(personId, availability)
+    // first manually put a AvailabilitySchema instance in the db
+    db.getState()[path] = AvailabilitySchema.fromModel(personId, availability)
 
-        val table = AvailabilityTable(db)
-        table.get(id, {
-            // then check that we can retrieve it
-            assertEquals(availability, it)
-        }, {})
-    }
+    val table = AvailabilityTable(db)
+    table.get(
+        id,
+        {
+          // then check that we can retrieve it
+          assertEquals(availability, it)
+        },
+        {})
+  }
 
-    @Test
-    fun addTest() {
-        val id = "0"
-        val personId = "personId"
-        val availability = Availability(
+  @Test
+  fun addTest() {
+    val id = "0"
+    val personId = "personId"
+    val availability =
+        Availability(
             id = id,
             status = AvailabilityStatus.MAYBE,
             timeSlot = TimeSlot.PM,
-            date = LocalDate.now()
-        )
-        val availabilitySchema = AvailabilitySchema.fromModel(personId, availability)
-        val db = MockDatabase()
+            date = LocalDate.now())
+    val availabilitySchema = AvailabilitySchema.fromModel(personId, availability)
+    val db = MockDatabase()
 
-        val table = AvailabilityTable(db)
+    val table = AvailabilityTable(db)
 
-        // add an availability model instance
-        table.add(personId, availability, {
-            // here id is 0 because the MockDatabase use
-            // a counter for id generation
-            val path = "${AvailabilityTable.PATH}/0"
-            // check that it was added correctly
-            assertEquals(availabilitySchema, db.getState()[path])
-        }, {})
-
-    }
+    // add an availability model instance
+    table.add(
+        personId,
+        availability,
+        {
+          // here id is 0 because the MockDatabase use
+          // a counter for id generation
+          val path = "${AvailabilityTable.PATH}/0"
+          // check that it was added correctly
+          assertEquals(availabilitySchema, db.getState()[path])
+        },
+        {})
+  }
 }

--- a/app/src/test/java/ch/epfl/skysync/database/tables/AvailabilityTableUnitTest.kt
+++ b/app/src/test/java/ch/epfl/skysync/database/tables/AvailabilityTableUnitTest.kt
@@ -1,0 +1,62 @@
+package ch.epfl.skysync.database.tables
+
+import ch.epfl.skysync.database.MockDatabase
+import ch.epfl.skysync.database.schemas.AvailabilitySchema
+import ch.epfl.skysync.model.Availability
+import ch.epfl.skysync.model.AvailabilityStatus
+import ch.epfl.skysync.model.TimeSlot
+import org.junit.Test
+import org.junit.Assert.*
+import java.time.LocalDate
+
+class AvailabilityTableUnitTest {
+
+    @Test
+    fun getTest() {
+        val id = "id-1"
+        val personId = "personId"
+        val availability = Availability(
+            id = id,
+            status = AvailabilityStatus.MAYBE,
+            timeSlot = TimeSlot.PM,
+            date = LocalDate.now()
+        )
+        val db = MockDatabase()
+        val path = "${AvailabilityTable.PATH}/$id"
+
+        // first manually put a AvailabilitySchema instance in the db
+        db.getState()[path] = AvailabilitySchema.fromModel(personId, availability)
+
+        val table = AvailabilityTable(db)
+        table.get(id, {
+            // then check that we can retrieve it
+            assertEquals(availability, it)
+        }, {})
+    }
+
+    @Test
+    fun addTest() {
+        val id = "0"
+        val personId = "personId"
+        val availability = Availability(
+            id = id,
+            status = AvailabilityStatus.MAYBE,
+            timeSlot = TimeSlot.PM,
+            date = LocalDate.now()
+        )
+        val availabilitySchema = AvailabilitySchema.fromModel(personId, availability)
+        val db = MockDatabase()
+
+        val table = AvailabilityTable(db)
+
+        // add an availability model instance
+        table.add(personId, availability, {
+            // here id is 0 because the MockDatabase use
+            // a counter for id generation
+            val path = "${AvailabilityTable.PATH}/0"
+            // check that it was added correctly
+            assertEquals(availabilitySchema, db.getState()[path])
+        }, {})
+
+    }
+}


### PR DESCRIPTION
Based on #67 for database setup.

Split data model into "schema" and "model", one for the database representation and one for the frontend representation.

Create schema, model and table classes for the Availability data model.

Close #54