### PR TITLE
handle non existing entries in AvailabilityCalendar

### DIFF
--- a/app/src/androidTest/java/ch/epfl/skysync/viewmodel/generalViewModelTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/viewmodel/generalViewModelTest.kt
@@ -25,7 +25,8 @@ class generalViewModelTest {
     val someTimeSlot = TimeSlot.AM
     val nonExistingDate =
         viewModel.user.value.availabilities.getAvailabilityStatus(someDate, someTimeSlot)
-    Assert.assertNull(nonExistingDate)
+    Assert.assertEquals(nonExistingDate, AvailabilityStatus.UNDEFINED)
+    Assert.assertEquals(viewModel.user.value.availabilities.getSize(), 0)
   }
 
   @Test

--- a/app/src/main/java/ch/epfl/skysync/models/calendar/AvailabilityStatus.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/calendar/AvailabilityStatus.kt
@@ -7,13 +7,15 @@ package ch.epfl.skysync.models.calendar
 enum class AvailabilityStatus {
   OK,
   MAYBE,
-  NO;
+  NO,
+  UNDEFINED;
 
   fun next(): AvailabilityStatus {
     return when (this) {
+      UNDEFINED -> OK
       OK -> MAYBE
       MAYBE -> NO
-      NO -> OK
+      NO -> UNDEFINED
     }
   }
 }

--- a/app/src/main/java/ch/epfl/skysync/models/calendar/CalendarModel.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/calendar/CalendarModel.kt
@@ -1,7 +1,6 @@
 package ch.epfl.skysync.models.calendar
 
 import java.time.LocalDate
-import java.time.temporal.ChronoUnit
 
 /**
  * represents a calendar where each slot uniquely defined by its date and timeslot contains a
@@ -14,42 +13,9 @@ import java.time.temporal.ChronoUnit
 abstract class CalendarModel<T : CalendarViewable> {
   protected val cells: MutableList<T> = mutableListOf()
 
-  /**
-   * fills the calendar with some init values of T
-   *
-   * @param from: the first date for which an entry in the calendar is initialized
-   * @param to: the last date (inclusive)
-   */
-  abstract fun initForRange(
-      from: LocalDate,
-      to: LocalDate,
-  )
-
   /** @return number of entries in calendar */
   fun getSize(): Int {
     return cells.size
-  }
-
-  /**
-   * creates the slots for the given interval and inits each slot with the given constructor lambda
-   *
-   * @param from first slot to be generated (inclusive)
-   * @param to last slot to be generated (inclusive)
-   * @param constructor: constructs a new instance for T as a function of the slot coordinates
-   */
-  protected fun initForRangeSuper(
-      from: LocalDate,
-      to: LocalDate,
-      constructor: (LocalDate, TimeSlot) -> T
-  ) {
-    val numberOfDays = from.until(to, ChronoUnit.DAYS)
-    var currentDate = from
-    for (i in 0..numberOfDays) {
-      for (timeSlot in TimeSlot.entries) {
-        cells.add(constructor(currentDate, timeSlot))
-      }
-      currentDate = currentDate.plusDays(1)
-    }
   }
 
   /**
@@ -76,7 +42,7 @@ abstract class CalendarModel<T : CalendarViewable> {
    * @param timeSlot the timeSlot coordinate of the slot
    * @param produceNewValue computes a new value as function of the coordinates and the old value
    */
-  fun setByDate(
+  protected fun setByDate(
       date: LocalDate,
       timeSlot: TimeSlot,
       produceNewValue: (LocalDate, TimeSlot, oldValue: T?) -> T
@@ -91,7 +57,7 @@ abstract class CalendarModel<T : CalendarViewable> {
    * @param timeSlot the timeSlot of the cell to remove
    * @return the removed value if it was found, null otherwise
    */
-  fun removeByDate(date: LocalDate, timeSlot: TimeSlot): T? {
+  protected fun removeByDate(date: LocalDate, timeSlot: TimeSlot): T? {
 
     val oldValue = getByDate(date, timeSlot)
     if (oldValue != null) {
@@ -105,7 +71,7 @@ abstract class CalendarModel<T : CalendarViewable> {
    * @param timeSlot timeSlot coordinate of slot
    * @return slot for given coordinates if found, else null
    */
-  fun getByDate(date: LocalDate, timeSlot: TimeSlot): T? {
+  protected fun getByDate(date: LocalDate, timeSlot: TimeSlot): T? {
     return cells.firstOrNull { it.date == date && it.timeSlot == timeSlot }
   }
 }

--- a/app/src/main/java/ch/epfl/skysync/models/calendar/FlightGroupCalendar.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/calendar/FlightGroupCalendar.kt
@@ -27,22 +27,21 @@ class FlightGroupCalendar : CalendarModel<FlightGroup>() {
   }
 
   /**
-   * inits the calendar with empty FlightGroups for the given range
-   *
-   * @param from start date of the range
-   * @param to end date of the range (inclusive)
+   * @param date date calendar slot coordinate
+   * @param timeSlot timeSlot calendar slot coordinate
+   * @return first flight of the FlightGroup for the given slot coordinates
    */
-  override fun initForRange(from: LocalDate, to: LocalDate) {
-    initForRangeSuper(from, to) { date, timeSlot -> FlightGroup(date, timeSlot, listOf()) }
+  fun getFirstFlightByDate(date: LocalDate, timeSlot: TimeSlot): Flight? {
+    val flightGroup = getByDate(date, timeSlot) ?: return null
+    return flightGroup.firstFlight()
   }
 
   /**
    * @param date date calendar slot coordinate
    * @param timeSlot timeSlot calendar slot coordinate
-   * @return first flight of the FlightGroup for the given slot coordinates
+   * @return the FlightGroup for the given slot coordinates or null if none exists
    */
-  fun getFlightByDate(date: LocalDate, timeSlot: TimeSlot): Flight? {
-    val flightGroup = getByDate(date, timeSlot) ?: return null
-    return flightGroup.firstFlight()
+  fun getFlightGroupByDate(date: LocalDate, timeSlot: TimeSlot): FlightGroup? {
+    return getByDate(date, timeSlot)
   }
 }

--- a/app/src/main/java/ch/epfl/skysync/screens/CalendarUI.kt
+++ b/app/src/main/java/ch/epfl/skysync/screens/CalendarUI.kt
@@ -57,6 +57,7 @@ fun showTile(date: LocalDate, slot: TimeSlot, size: Dp) {
         AvailabilityStatus.OK -> Color.Green
         AvailabilityStatus.MAYBE -> Color.Blue
         AvailabilityStatus.NO -> Color.Red
+        AvailabilityStatus.UNDEFINED -> Color.Gray
       }
 
   Box(

--- a/app/src/test/java/ch/epfl/skysync/model/calendar/TestAvailabilityCalendar.kt
+++ b/app/src/test/java/ch/epfl/skysync/model/calendar/TestAvailabilityCalendar.kt
@@ -15,119 +15,94 @@ import org.junit.Test
  * See [testing documentation](http://d.android.com/tools/testing).
  */
 class TestAvailabilityCalendar {
-  var availabilities = listOf<Availability>()
+  var defaultAvailabilities = listOf<Availability>()
   var calendar = AvailabilityCalendar()
+  var someDate = LocalDate.of(2024, 4, 1)
 
   @Before
   fun setUp() {
-    val av1 = Availability("1", AvailabilityStatus.OK, TimeSlot.AM, LocalDate.now())
-    val av2 = Availability("2", AvailabilityStatus.OK, TimeSlot.AM, LocalDate.now().plusDays(1))
-    availabilities = listOf(av1, av2)
+    someDate = LocalDate.of(2024, 4, 1)
+    val defaultAvailability1 = Availability("1", AvailabilityStatus.OK, TimeSlot.AM, someDate)
+    val defaultAvailability2 =
+        Availability("2", AvailabilityStatus.MAYBE, TimeSlot.PM, someDate.plusDays(1))
+    defaultAvailabilities = listOf(defaultAvailability1, defaultAvailability2)
     calendar = AvailabilityCalendar()
   }
 
   @Test
-  fun `finds an availability by date and time slot`() {
+  fun `finds an availability status by date and time slot`() {
     val calendar = AvailabilityCalendar()
-    calendar.addCells(availabilities)
-    val av1 = availabilities[0]
-    val av2 = availabilities[1]
-    assertEquals(calendar.getByDate(av1.date, av1.timeSlot), av1)
-    assertEquals(calendar.getByDate(av2.date, av2.timeSlot), av2)
+    calendar.addCells(defaultAvailabilities)
+    val av1 = defaultAvailabilities[0]
+    val av2 = defaultAvailabilities[1]
+    assertEquals(calendar.getAvailabilityStatus(av1.date, av1.timeSlot), av1.status)
+    assertEquals(calendar.getAvailabilityStatus(av2.date, av2.timeSlot), av2.status)
   }
 
   @Test
   fun `add a new availability by date and time slot`() {
     val calendar = AvailabilityCalendar()
-    val av1 = availabilities[0]
-    calendar.setAvailabilityByDate(av1.date, av1.timeSlot, av1.status)
-    assertEquals(calendar.getAvailabilityStatus(av1.date, av1.timeSlot), av1.status)
+    val newStatus = AvailabilityStatus.OK
+    val timeSlot = TimeSlot.PM
+    calendar.setAvailabilityByDate(someDate, timeSlot, newStatus)
+    assertEquals(calendar.getAvailabilityStatus(someDate, timeSlot), newStatus)
   }
 
   @Test
-  fun `change an availability status by date and time slot`() {
-    calendar.addCells(availabilities)
-    val av1 = availabilities[0]
-    val av2 = availabilities[1]
+  fun `change an availability status by date and time slot without changing others`() {
+    val initAvailability = Availability("1", AvailabilityStatus.MAYBE, TimeSlot.AM, someDate)
+    val initAvailability2 = Availability("1", AvailabilityStatus.OK, TimeSlot.PM, someDate)
+    calendar.addCells(listOf(initAvailability, initAvailability2))
     val new_status = AvailabilityStatus.NO
-    calendar.setAvailabilityByDate(av1.date, av1.timeSlot, new_status)
-    val av1_expected = Availability(av1.id, new_status, av1.timeSlot, av1.date)
+    calendar.setAvailabilityByDate(initAvailability.date, initAvailability.timeSlot, new_status)
     // check availability is changed
-    assertEquals(calendar.getByDate(av1.date, av1.timeSlot), av1_expected)
+    assertEquals(
+        calendar.getAvailabilityStatus(initAvailability.date, initAvailability.timeSlot),
+        new_status)
     // check other availability is not changed
-    assertEquals(calendar.getByDate(av2.date, av2.timeSlot), av2)
+    assertEquals(
+        calendar.getAvailabilityStatus(initAvailability2.date, initAvailability2.timeSlot),
+        AvailabilityStatus.OK)
   }
 
   @Test
-  fun `remove an existing availability by date and time slot`() {
-    calendar.addCells(availabilities)
-    val av1 = availabilities[0]
-    val av2 = availabilities[1]
-    assertEquals(calendar.removeByDate(av1.date, av1.timeSlot), av1)
-    // check only the first availability is removed
-    assertEquals(calendar.getByDate(av2.date, av2.timeSlot), av2)
-  }
-
-  @Test
-  fun `remove non existing availability by date and time slot`() {
-    calendar.addCells(availabilities.take(1))
-    val av1 = availabilities[0]
-    val av2 = availabilities[1]
-    // check that av2 is initially not in the calendar
-    assertEquals(calendar.getByDate(av2.date, av2.timeSlot), null)
-    // check that removing av2 does not change the calendar
-    assertEquals(calendar.removeByDate(av2.date, av2.timeSlot), null)
-    assertEquals(calendar.getByDate(av1.date, av1.timeSlot), av1)
-  }
-
-  @Test
-  fun `init range`() {
-    val number_of_days: Long = 7
-    val start = LocalDate.of(2021, 1, 1)
-    val end = start.plusDays(number_of_days)
-    calendar.initForRange(start, end)
-    val expectedNumberOfCells = (number_of_days.toInt() + 1) * TimeSlot.entries.size
-    assertEquals(calendar.getSize(), expectedNumberOfCells)
-    for (i in 0..number_of_days) {
-      for (timeSlot in TimeSlot.entries) {
-        val av = calendar.getByDate(start.plusDays(i), timeSlot)
-        assertNotNull(av)
-      }
-    }
-  }
-
-  @Test
-  fun `add rejects cells with same data and timeslot`() {
-    calendar.addCells(availabilities)
-    assertThrows(IllegalArgumentException::class.java) { calendar.addCells(availabilities.take(1)) }
-    assertThrows(IllegalArgumentException::class.java) { calendar.addCells(availabilities) }
-  }
-
-  @Test
-  fun `getAvailabilityStatus returns current status`() {
+  fun `nextAvailabilityStatus updates existing entry to next status and returns correctly`() {
     val calendar = AvailabilityCalendar()
-    calendar.addCells(availabilities)
-    val av1 = availabilities[0]
-    assertEquals(calendar.getAvailabilityStatus(av1.date, av1.timeSlot), av1.status)
+    val availability1 = Availability("1", AvailabilityStatus.MAYBE, TimeSlot.AM, someDate)
+    calendar.addCells(listOf(availability1))
+    assertEquals(
+        calendar.nextAvailabilityStatus(availability1.date, availability1.timeSlot),
+        availability1.status.next())
   }
 
   @Test
-  fun `nextAvailabilityStatus updates to next status and returns correctly`() {
+  fun `nextAvailabilityStatus initialises non-existing entry to OK and returns correctly`() {
     val calendar = AvailabilityCalendar()
-    calendar.addCells(availabilities)
-    val av1 = availabilities[0]
-    assertEquals(calendar.nextAvailabilityStatus(av1.date, av1.timeSlot), av1.status.next())
-    // check calendar is correctly updated
-    assertEquals(calendar.getByDate(av1.date, av1.timeSlot)?.status, av1.status.next())
+    val availability1 = Availability("1", AvailabilityStatus.MAYBE, TimeSlot.AM, someDate)
+    assertEquals(
+        calendar.nextAvailabilityStatus(availability1.date, availability1.timeSlot),
+        AvailabilityStatus.OK)
   }
 
   @Test
-  fun `size is correctly updated`() {
+  fun `nextAvailabilityStatus removes NO and returns UNDEFINED`() {
     val calendar = AvailabilityCalendar()
-    calendar.addCells(availabilities)
-    val av1 = availabilities[0]
-    assertEquals(calendar.getSize(), availabilities.size)
-    calendar.removeByDate(av1.date, av1.timeSlot)
-    assertEquals(calendar.getSize(), availabilities.size - 1)
+    val availability1 = Availability("1", AvailabilityStatus.NO, TimeSlot.AM, someDate)
+    calendar.addCells(listOf(availability1))
+    assertEquals(
+        calendar.nextAvailabilityStatus(availability1.date, availability1.timeSlot),
+        AvailabilityStatus.UNDEFINED)
+    assertEquals(calendar.getSize(), 0)
+  }
+
+  @Test
+  fun `size is correctly returned`() {
+    val calendar = AvailabilityCalendar()
+    val availability1 = Availability("1", AvailabilityStatus.NO, TimeSlot.AM, someDate)
+    calendar.addCells(listOf(availability1))
+    assertEquals(calendar.getSize(), 1)
+    val availability2 = Availability("2", AvailabilityStatus.MAYBE, TimeSlot.PM, someDate)
+    calendar.addCells(listOf(availability2))
+    assertEquals(calendar.getSize(), 2)
   }
 }

--- a/app/src/test/java/ch/epfl/skysync/model/calendar/TestFlightGroupCalendar.kt
+++ b/app/src/test/java/ch/epfl/skysync/model/calendar/TestFlightGroupCalendar.kt
@@ -1,6 +1,5 @@
 package ch.epfl.skysync.model.calendar
 
-import ch.epfl.skysync.models.UNSET_ID
 import ch.epfl.skysync.models.calendar.FlightGroup
 import ch.epfl.skysync.models.calendar.FlightGroupCalendar
 import ch.epfl.skysync.models.calendar.TimeSlot
@@ -21,16 +20,28 @@ import org.junit.Test
 class TestFlightGroupCalendar {
   lateinit var calendar: FlightGroupCalendar
   lateinit var testFlight: Flight
+  lateinit var testFlight2: Flight
   lateinit var emptyFlightGroup: FlightGroup
 
   @Before
   fun setUp() {
     testFlight =
         PlannedFlight(
-            UNSET_ID,
+            "y",
             1,
             Team(listOf()),
             FlightType.FONDUE,
+            null,
+            null,
+            LocalDate.of(2024, 4, 1),
+            TimeSlot.AM,
+            listOf())
+    testFlight2 =
+        PlannedFlight(
+            "x",
+            2,
+            Team(listOf()),
+            FlightType.DISCOVERY,
             null,
             null,
             LocalDate.of(2024, 4, 1),
@@ -41,111 +52,48 @@ class TestFlightGroupCalendar {
   }
 
   @Test
-  fun `initForRange() inits empty groups for interval `() {
-    val start = LocalDate.of(2024, 4, 1)
-    val days: Long = 7
-    calendar.initForRange(start, start.plusDays(days - 1))
-    assertEquals(calendar.getSize(), days.toInt() * TimeSlot.entries.size)
-    for (i in 0 until days) {
-      for (timeSlot in TimeSlot.entries) {
-        val group = calendar.getByDate(start.plusDays(i), timeSlot)
-        assertNotNull(group)
-        if (group != null) {
-          assertTrue(group.isEmpty())
-        }
-      }
-    }
-  }
-
-  @Test
-  fun `getFlightByDate() returns null if no flights found `() {
+  fun `getFirstFlightByDate() returns null if no flights found `() {
 
     calendar.addCells(listOf(emptyFlightGroup))
-    calendar.getFlightByDate(emptyFlightGroup.date, emptyFlightGroup.timeSlot)
-    assertEquals(calendar.getFlightByDate(emptyFlightGroup.date, emptyFlightGroup.timeSlot), null)
+    calendar.getFirstFlightByDate(emptyFlightGroup.date, emptyFlightGroup.timeSlot)
+    assertEquals(
+        calendar.getFirstFlightByDate(emptyFlightGroup.date, emptyFlightGroup.timeSlot), null)
   }
 
   @Test
-  fun `getFlightByDate() returns first flight if flight found`() {
+  fun `getFlightGroupByDate() returns null if no flight found  for date`() {
+    val someDate = LocalDate.of(2024, 4, 1)
+    assertNull(calendar.getFlightGroupByDate(someDate, TimeSlot.AM))
+  }
+
+  @Test
+  fun `getFlightGroupByDate() returns the flight group if found`() {
+    val flightGroup = FlightGroup(testFlight.date, testFlight.timeSlot, listOf(testFlight))
+    calendar.addCells(listOf(flightGroup))
+    val foundFlightGroup = calendar.getFlightGroupByDate(testFlight.date, testFlight.timeSlot)
+    assertEquals(foundFlightGroup, flightGroup)
+  }
+
+  @Test
+  fun `getFirstFlightByDate() returns first flight if flight found`() {
     calendar.addCells(listOf(FlightGroup(testFlight.date, testFlight.timeSlot, listOf(testFlight))))
-    val foundFlight = calendar.getFlightByDate(testFlight.date, testFlight.timeSlot)
+    val foundFlight = calendar.getFirstFlightByDate(testFlight.date, testFlight.timeSlot)
     assertNotNull(foundFlight)
     if (foundFlight != null) {
       assertEquals(foundFlight, testFlight)
     }
   }
 
-  //  @Test
-  //  fun `remove an existing availability by date and time slot`() {
-  //    calendar.addCells(availabilities)
-  //    val av1 = availabilities[0]
-  //    val av2 = availabilities[1]
-  //    assertEquals(calendar.removeByDate(av1.date, av1.timeSlot), av1)
-  //    // check only the first availability is removed
-  //    assertEquals(calendar.getByDate(av2.date, av2.timeSlot), av2)
-  //  }
-  //
-  //  @Test
-  //  fun `remove non existing availability by date and time slot`() {
-  //    calendar.addCells(availabilities.take(1))
-  //    val av1 = availabilities[0]
-  //    val av2 = availabilities[1]
-  //    // check that av2 is initially not in the calendar
-  //    assertEquals(calendar.getByDate(av2.date, av2.timeSlot), null)
-  //    // check that removing av2 does not change the calendar
-  //    assertEquals(calendar.removeByDate(av2.date, av2.timeSlot), null)
-  //    assertEquals(calendar.getByDate(av1.date, av1.timeSlot), av1)
-  //  }
-  //
-  //  @Test
-  //  fun `init range`() {
-  //    val number_of_days: Long = 7
-  //    val start = LocalDate.of(2021, 1, 1)
-  //    val end = start.plusDays(number_of_days)
-  //    calendar.initForRange(start, end)
-  //    val expectedNumberOfCells = (number_of_days.toInt() + 1) * TimeSlot.entries.size
-  //    assertEquals(calendar.size, expectedNumberOfCells)
-  //    for (i in 0..number_of_days) {
-  //      for (timeSlot in TimeSlot.entries) {
-  //        val av = calendar.getByDate(start.plusDays(i), timeSlot)
-  //        assertNotNull(av)
-  //      }
-  //    }
-  //  }
-  //
-  //  @Test
-  //  fun `add rejects cells with same data and timeslot`() {
-  //    calendar.addCells(availabilities)
-  //    assertThrows(IllegalArgumentException::class.java) {
-  // calendar.addCells(availabilities.take(1)) }
-  //    assertThrows(IllegalArgumentException::class.java) { calendar.addCells(availabilities) }
-  //  }
-  //
-  //  @Test
-  //  fun `getAvailabilityStatus returns current status`() {
-  //    val calendar = AvailabilityCalendar()
-  //    calendar.addCells(availabilities)
-  //    val av1 = availabilities[0]
-  //    assertEquals(calendar.getAvailabilityStatus(av1.date, av1.timeSlot), av1.status)
-  //  }
-  //
-  //  @Test
-  //  fun `nextAvailabilityStatus updates to next status and returns correctly`() {
-  //    val calendar = AvailabilityCalendar()
-  //    calendar.addCells(availabilities)
-  //    val av1 = availabilities[0]
-  //    assertEquals(calendar.nextAvailabilityStatus(av1.date, av1.timeSlot), av1.status.next())
-  //    // check calendar is correctly updated
-  //    assertEquals(calendar.getByDate(av1.date, av1.timeSlot)?.status, av1.status.next())
-  //  }
-  //
-  //  @Test
-  //  fun `size is correctly updated`() {
-  //    val calendar = AvailabilityCalendar()
-  //    calendar.addCells(availabilities)
-  //    val av1 = availabilities[0]
-  //    assertEquals(calendar.size, availabilities.size)
-  //    calendar.removeByDate(av1.date, av1.timeSlot)
-  //    assertEquals(calendar.size, availabilities.size - 1)
-  //  }
+  @Test
+  fun `add flight to an existing flight group`() {
+    calendar.addCells(listOf(FlightGroup(testFlight.date, testFlight.timeSlot, listOf(testFlight))))
+    calendar.addFlightByDate(testFlight2.date, testFlight2.timeSlot, testFlight2)
+    assertEquals(calendar.getSize(), 1)
+    val foundGroup = calendar.getFlightGroupByDate(testFlight2.date, testFlight2.timeSlot)
+    assertNotNull(foundGroup)
+    if (foundGroup != null) {
+      assertTrue(foundGroup.flights.contains(testFlight2))
+      assertTrue(foundGroup.flights.contains(testFlight))
+    }
+  }
 }


### PR DESCRIPTION
closes #116 

the AvailabilityCalendar now implements following strat:

- getAvailabilityStatus() returns the AvailabilityStatus of the found entry else UNDEFINED (also an AvailabilityStatus) if not present (instead of null)
- nextAvailabilityStatus() returns next status (in round-robin fashion). 
    -  If the entry is not yet present it initializes(adds the entry) with AvailabilityStatus = OK. 
    - If the current status == NO, then it returns UNDEFINED and removes the entry
 
the round-robin was updated to:
UNDEFINED -> OK -> MAYBE -> NO -> UNDEFINED

Before the null value in the case of a non-existing entry had to be considered separately which is no longer the case