### PR TITLE
Calendar UI remake

### DIFF
--- a/app/src/androidTest/java/ch/epfl/skysync/CalendarUITest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/CalendarUITest.kt
@@ -1,0 +1,127 @@
+package ch.epfl.skysync
+
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.compose.NavHost
+import androidx.navigation.testing.TestNavHostController
+import ch.epfl.skysync.models.calendar.TimeSlot
+import ch.epfl.skysync.navigation.Route
+import ch.epfl.skysync.navigation.homeGraph
+import ch.epfl.skysync.screens.getStartOfWeek
+import java.time.LocalDate
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class CalendarUITest {
+  @get:Rule val composeTestRule = createComposeRule()
+  lateinit var navController: TestNavHostController
+
+  @Before
+  fun setUpNavHost() {
+    composeTestRule.setContent {
+      navController = TestNavHostController(LocalContext.current)
+      navController.navigatorProvider.addNavigator(ComposeNavigator())
+      NavHost(navController = navController, startDestination = Route.MAIN) {
+        homeGraph(navController)
+      }
+      navController.navigate(Route.CALENDAR)
+    }
+  }
+
+  @Test
+  fun verifyFlightCalendarIsStartDestination() {
+    val route = navController.currentBackStackEntry?.destination?.route
+    Assert.assertEquals(route, Route.CALENDAR)
+  }
+
+  @Test
+  fun routeIsRightIfClickOnAddTodayDate() {
+    var previewDate = LocalDate.now()
+    val testTag = previewDate.toString() + TimeSlot.AM.toString()
+    composeTestRule.onNode(hasTestTag(testTag)).performClick()
+
+    val route = navController.currentBackStackEntry?.destination?.route
+    Assert.assertEquals(route, Route.CALENDAR)
+  }
+
+  @Test
+  fun routeIsRightIfClickOnMondayAm() {
+    var previewDate = getStartOfWeek(LocalDate.now())
+    val testTag = previewDate.toString() + TimeSlot.AM.toString()
+    composeTestRule.onNode(hasTestTag(testTag)).performClick()
+
+    val route = navController.currentBackStackEntry?.destination?.route
+    Assert.assertEquals(route, Route.CALENDAR)
+  }
+
+  @Test
+  fun routeIsRightIfClickOnMondayPm() {
+    var previewDate = getStartOfWeek(LocalDate.now())
+    val testTag = previewDate.toString() + TimeSlot.PM.toString()
+    composeTestRule.onNode(hasTestTag(testTag)).performClick()
+
+    val route = navController.currentBackStackEntry?.destination?.route
+    Assert.assertEquals(route, Route.CALENDAR)
+  }
+
+  @Test
+  fun routeIsRightIfClickOnTuesdayAm() {
+    var previewDate = getStartOfWeek(LocalDate.now()).plusDays(1)
+    val testTag = previewDate.toString() + TimeSlot.AM.toString()
+    composeTestRule.onNode(hasTestTag(testTag)).performClick()
+
+    val route = navController.currentBackStackEntry?.destination?.route
+    Assert.assertEquals(route, Route.CALENDAR)
+  }
+
+  @Test
+  fun routeIsRightIfClickOnTuesdayPm() {
+    var previewDate = getStartOfWeek(LocalDate.now()).plusDays(1)
+    val testTag = previewDate.toString() + TimeSlot.PM.toString()
+    composeTestRule.onNode(hasTestTag(testTag)).performClick()
+
+    val route = navController.currentBackStackEntry?.destination?.route
+    Assert.assertEquals(route, Route.CALENDAR)
+  }
+
+  @Test
+  fun routeIsRightIfClickOnWednesdayAm() {
+    var previewDate = getStartOfWeek(LocalDate.now()).plusDays(2)
+    val testTag = previewDate.toString() + TimeSlot.AM.toString()
+    composeTestRule.onNode(hasTestTag(testTag)).performClick()
+
+    val route = navController.currentBackStackEntry?.destination?.route
+    Assert.assertEquals(route, Route.CALENDAR)
+  }
+
+  @Test
+  fun routeIsRightIfClickOnWednesdayPm() {
+    var previewDate = getStartOfWeek(LocalDate.now()).plusDays(2)
+    val testTag = previewDate.toString() + TimeSlot.PM.toString()
+    composeTestRule.onNode(hasTestTag(testTag)).performClick()
+
+    val route = navController.currentBackStackEntry?.destination?.route
+    Assert.assertEquals(route, Route.CALENDAR)
+  }
+
+  @Test
+  fun routeIsRightIfClickOnNext() {
+    composeTestRule.onNodeWithText("Next Week").performClick()
+    val route = navController.currentBackStackEntry?.destination?.route
+    Assert.assertEquals(route, Route.CALENDAR)
+  }
+
+  @Test
+  fun routeIsRightIfClickOnPrev() {
+    composeTestRule.onNodeWithText("Prev Week").performClick()
+
+    val route = navController.currentBackStackEntry?.destination?.route
+    Assert.assertEquals(route, Route.CALENDAR)
+  }
+}

--- a/app/src/main/java/ch/epfl/skysync/screens/Calendar.kt
+++ b/app/src/main/java/ch/epfl/skysync/screens/Calendar.kt
@@ -23,6 +23,7 @@ fun CalendarScreen(navController: NavHostController) {
         fontSize = MaterialTheme.typography.displayLarge.fontSize,
         fontWeight = FontWeight.Bold,
         color = Color.Black)
+    CalendarPreview()
   }
 }
 

--- a/app/src/main/java/ch/epfl/skysync/screens/CalendarUI.kt
+++ b/app/src/main/java/ch/epfl/skysync/screens/CalendarUI.kt
@@ -200,26 +200,3 @@ fun WeekView(startOfWeek: LocalDate, viewModel: UserViewModel) {
 fun getStartOfWeek(date: LocalDate): LocalDate {
   return date.minusDays(date.dayOfWeek.value.toLong() - 1)
 }
-
-/**
- * Determines the availability status for a given date and time slot. Dummy function that always
- * returns AvailabilityStatus.OK.
- *
- * @param date The date for which availability status is being checked.
- * @param slot The time slot for which availability status is being checked.
- * @return The availability status for the specified date and time slot.
- */
-fun getAvailabilityStatus(date: LocalDate, slot: TimeSlot): AvailabilityStatus? {
-  return AvailabilityStatus.OK
-}
-/**
- * Determines the availability status for a given date and time slot. Dummy function that always
- * returns AvailabilityStatus.NO.
- *
- * @param date The date for which availability status is being checked.
- * @param slot The time slot for which availability status is being checked.
- * @return The availability status for the specified date and time slot.
- */
-fun nextAvailabilityStatus(date: LocalDate, slot: TimeSlot): AvailabilityStatus? {
-  return null
-}


### PR DESCRIPTION
Pull Request Description
------------------------

### Overview
Close #103

Remake of calendarAvailability UI

### Changes Made

*   Used functions `getAvailabilityStatus` and `nextAvailabilityStatus` to determine and update the availability status for a given date and time slot from the given viewModel user
*   fixed the composable function `showTile` to display colored tiles indicating the availability status updated with the weeks changed.
*   Made the tiles bigger and realigned the AM and PM signs to realign more with the Figma demos

### Android render:

![Screenshot from 2024-04-11 15-27-42](https://github.com/SkySync-EPFL/skysync/assets/126060486/ea0c190d-c94e-4afc-9ffd-38fb8063c179)

