### PR TITLE
Fix User roleTypes

### DIFF
--- a/app/src/main/java/ch/epfl/skysync/database/schemas/UserSchema.kt
+++ b/app/src/main/java/ch/epfl/skysync/database/schemas/UserSchema.kt
@@ -30,6 +30,7 @@ data class UserSchema(
               lastname = lastname!!,
               availabilities = AvailabilityCalendar(),
               assignedFlights = FlightGroupCalendar(),
+              roleTypes = roleTypes!!.toSet(),
           )
       UserRole.CREW ->
           Crew(
@@ -38,6 +39,7 @@ data class UserSchema(
               lastname = lastname!!,
               availabilities = AvailabilityCalendar(),
               assignedFlights = FlightGroupCalendar(),
+              roleTypes = roleTypes!!.toSet(),
           )
       UserRole.PILOT ->
           Pilot(
@@ -46,6 +48,7 @@ data class UserSchema(
               lastname = lastname!!,
               availabilities = AvailabilityCalendar(),
               assignedFlights = FlightGroupCalendar(),
+              roleTypes = roleTypes!!.toSet(),
               qualification = balloonQualification!!)
     }
   }
@@ -66,7 +69,7 @@ data class UserSchema(
           userRole = userRole,
           firstname = model.firstname,
           lastname = model.lastname,
-          roleTypes = listOf(),
+          roleTypes = model.roleTypes.toList(),
           balloonQualification = qualification)
     }
   }

--- a/app/src/main/java/ch/epfl/skysync/models/user/Admin.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/user/Admin.kt
@@ -11,14 +11,9 @@ data class Admin(
     override val lastname: String,
     override val availabilities: AvailabilityCalendar,
     override val assignedFlights: FlightGroupCalendar,
+    override val roleTypes: Set<RoleType> = setOf(),
 ) : User {
-  private val roleTypes: Set<RoleType> = setOf()
-
   override fun addRoleType(roleType: RoleType): Admin {
-    throw NotImplementedError()
-  }
-
-  override fun canAssumeRole(roleType: RoleType): Boolean {
-    return roleTypes.contains(roleType)
+    return this.copy(roleTypes = roleTypes + roleType)
   }
 }

--- a/app/src/main/java/ch/epfl/skysync/models/user/Crew.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/user/Crew.kt
@@ -11,15 +11,9 @@ data class Crew(
     override val lastname: String,
     override val availabilities: AvailabilityCalendar,
     override val assignedFlights: FlightGroupCalendar,
+    override val roleTypes: Set<RoleType> = setOf(RoleType.CREW),
 ) : User {
-
-  private val roleTypes: Set<RoleType> = setOf(RoleType.CREW)
-
   override fun addRoleType(roleType: RoleType): Crew {
-    throw NotImplementedError()
-  }
-
-  override fun canAssumeRole(roleType: RoleType): Boolean {
-    return roleTypes.contains(roleType)
+    return this.copy(roleTypes = roleTypes + roleType)
   }
 }

--- a/app/src/main/java/ch/epfl/skysync/models/user/Pilot.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/user/Pilot.kt
@@ -12,17 +12,11 @@ data class Pilot(
     override val lastname: String,
     override val availabilities: AvailabilityCalendar,
     override val assignedFlights: FlightGroupCalendar,
+    override val roleTypes: Set<RoleType> = setOf(RoleType.CREW, RoleType.PILOT),
     val qualification: BalloonQualification,
 ) : User {
-  private val roleTypes: Set<RoleType> = setOf(RoleType.CREW, RoleType.PILOT)
 
   override fun addRoleType(roleType: RoleType): Pilot {
-    throw NotImplementedError()
-  }
-
-  override fun canAssumeRole(roleType: RoleType): Boolean {
-    return roleTypes.contains(roleType)
+    return this.copy(roleTypes = roleTypes + roleType)
   }
 }
-
-// val examplePilot = Pilot("John", "Doe", "1234", BalloonQualification.LARGE)

--- a/app/src/main/java/ch/epfl/skysync/models/user/User.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/user/User.kt
@@ -10,8 +10,11 @@ interface User {
   val lastname: String
   val availabilities: AvailabilityCalendar
   val assignedFlights: FlightGroupCalendar
+  val roleTypes: Set<RoleType>
 
   fun addRoleType(roleType: RoleType): User
 
-  fun canAssumeRole(roleType: RoleType): Boolean
+  fun canAssumeRole(roleType: RoleType): Boolean {
+    return roleTypes.contains(roleType)
+  }
 }

--- a/app/src/test/java/ch/epfl/skysync/model/user/TestUsers.kt
+++ b/app/src/test/java/ch/epfl/skysync/model/user/TestUsers.kt
@@ -4,17 +4,14 @@ import ch.epfl.skysync.models.UNSET_ID
 import ch.epfl.skysync.models.calendar.AvailabilityCalendar
 import ch.epfl.skysync.models.calendar.FlightGroupCalendar
 import ch.epfl.skysync.models.flight.BalloonQualification
+import ch.epfl.skysync.models.flight.RoleType
 import ch.epfl.skysync.models.user.Admin
 import ch.epfl.skysync.models.user.Crew
 import ch.epfl.skysync.models.user.Pilot
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 
-/**
- * Example local unit test, which will execute on the development machine (host).
- *
- * See [testing documentation](http://d.android.com/tools/testing).
- */
 class TestUsers {
 
   @Before fun setUp() {}
@@ -28,7 +25,14 @@ class TestUsers {
             UNSET_ID,
             AvailabilityCalendar(),
             FlightGroupCalendar(),
+            setOf(RoleType.PILOT, RoleType.CREW),
             BalloonQualification.LARGE)
+
+    val pilotWithRoleType = pilot.addRoleType(RoleType.MAITRE_FONDUE)
+    assertEquals(false, pilot.canAssumeRole(RoleType.MAITRE_FONDUE))
+    assertEquals(true, pilotWithRoleType.canAssumeRole(RoleType.MAITRE_FONDUE))
+    assertEquals(
+        setOf(RoleType.PILOT, RoleType.CREW, RoleType.MAITRE_FONDUE), pilotWithRoleType.roleTypes)
   }
 
   @Test


### PR DESCRIPTION
Set the `roleTypes` attribute in `User` (thus public) instead of previously private attribute defined in each Pilot, Crew, Admin

Close #164