### PR TITLE
change timer to continue running on all screens

### DIFF
--- a/app/src/androidTest/java/ch/epfl/skysync/components/TimerTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/components/TimerTest.kt
@@ -16,7 +16,14 @@ class TimerTest {
 
   @Before
   fun setUp() {
-    composeTestRule.setContent { Timer(modifier = Modifier) }
+    composeTestRule.setContent {
+      Timer(
+        modifier = Modifier,
+        currentTimer = "0:0:0",
+        isRunning = false,
+        onStart = {},
+        onStop = {})
+    }
   }
 
   @Test

--- a/app/src/androidTest/java/ch/epfl/skysync/components/TimerTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/components/TimerTest.kt
@@ -1,58 +1,61 @@
 package ch.epfl.skysync.components
 
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.assertTextContains
-import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import org.junit.Before
+import org.junit.Assert.assertFalse
 import org.junit.Rule
 import org.junit.Test
 
 class TimerTest {
   @get:Rule val composeTestRule = createComposeRule()
 
-  @Before
-  fun setUp() {
+  @Test
+  fun timerIsDisplayedWithWithButton() {
     composeTestRule.setContent {
       Timer(
-        modifier = Modifier,
-        currentTimer = "0:0:0",
-        isRunning = false,
-        onStart = {},
-        onStop = {})
+          modifier = Modifier, currentTimer = "0:0:0", isRunning = false, onStart = {}, onStop = {})
     }
-  }
-
-  @Test
-  fun timerIsDisplayed() {
     composeTestRule.onNodeWithTag("Timer").assertExists()
+    composeTestRule.onNodeWithTag("Timer Value").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("Start Button").assertIsDisplayed()
+    composeTestRule.onNodeWithText("0:0:0").assertIsDisplayed()
   }
 
   @Test
-  fun timerValueIsDisplayed() {
-    composeTestRule.onNodeWithTag("Timer Value").assertExists()
-  }
-
-  @Test
-  fun timerStartButtonIsDisplayed() {
-    composeTestRule.onNodeWithTag("Start Button").assertExists()
-  }
-
-  @OptIn(ExperimentalTestApi::class)
-  @Test
-  fun timerResetButtonIsDisplayed() {
-    composeTestRule.onNodeWithTag("Timer Value").assertTextContains("00:00:00")
+  fun correctButtonIsDisplayedAndClickableIfPaused() {
+    var controlVariableOnStart = false
+    var controlVariableOnStop = false
+    composeTestRule.setContent {
+      Timer(
+          modifier = Modifier,
+          currentTimer = "0:0:0",
+          isRunning = false,
+          onStart = { controlVariableOnStart = true },
+          onStop = { controlVariableOnStop = true })
+    }
     composeTestRule.onNodeWithTag("Start Button").performClick()
-    composeTestRule.waitUntilAtLeastOneExists(
-        hasText("00:00:02", substring = true), timeoutMillis = 2010)
-    composeTestRule.onNodeWithTag("Reset Button").assertExists()
+    assert(controlVariableOnStart)
+    assertFalse(controlVariableOnStop)
   }
 
   @Test
-  fun timerValueIsUpdated() {
-    composeTestRule.onNodeWithTag("Start Button").performClick()
+  fun correctButtonIsDisplayedAndClickableIfRunning() {
+    var controlVariableOnStart = false
+    var controlVariableOnStop = false
+    composeTestRule.setContent {
+      Timer(
+          modifier = Modifier,
+          currentTimer = "0:0:0",
+          isRunning = true,
+          onStart = { controlVariableOnStart = true },
+          onStop = { controlVariableOnStop = true })
+    }
+    composeTestRule.onNodeWithTag("Stop Button").performClick()
+    assert(controlVariableOnStop)
+    assertFalse(controlVariableOnStart)
   }
 }

--- a/app/src/androidTest/java/ch/epfl/skysync/screens/flight/FlightScreenNoPermissionTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/screens/flight/FlightScreenNoPermissionTest.kt
@@ -8,6 +8,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
 import ch.epfl.skysync.screens.FlightScreen
+import ch.epfl.skysync.viewmodel.TimerViewModel
 import org.junit.Rule
 import org.junit.Test
 
@@ -21,7 +22,7 @@ class FlightScreenNoPermissionTest {
 
     composeTestRule.setContent {
       val navController = rememberNavController()
-      FlightScreen(navController)
+      FlightScreen(navController, TimerViewModel.createViewModel())
     }
 
     val denyButton = uiDevice.findObject(UiSelector().text("Don’t allow"))

--- a/app/src/androidTest/java/ch/epfl/skysync/screens/flight/FlightScreenPermissionTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/screens/flight/FlightScreenPermissionTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.performClick
 import androidx.navigation.compose.rememberNavController
 import androidx.test.rule.GrantPermissionRule
 import ch.epfl.skysync.screens.FlightScreen
+import ch.epfl.skysync.viewmodel.TimerViewModel
 import org.junit.Rule
 import org.junit.Test
 
@@ -24,7 +25,7 @@ class FlightScreenPermissionTest {
   fun flightScreen_PermissionGranted_ShowsMapAndFAB() {
     composeTestRule.setContent {
       val navController = rememberNavController()
-      FlightScreen(navController)
+      FlightScreen(navController, TimerViewModel.createViewModel())
     }
 
     composeTestRule.onNodeWithTag("LoadingIndicator").assertIsNotDisplayed()

--- a/app/src/androidTest/java/ch/epfl/skysync/viewmodel/TimerViewModelTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/viewmodel/TimerViewModelTest.kt
@@ -1,0 +1,68 @@
+package ch.epfl.skysync.viewmodel
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.delay
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class TimerViewModelTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+    lateinit var timerViewModel: TimerViewModel
+
+    @Before
+    fun setUp() {
+        composeTestRule.setContent {
+            timerViewModel = TimerViewModel.createViewModel()
+            val countString by timerViewModel.counter.collectAsStateWithLifecycle()
+            Text(countString)
+        }
+    }
+
+
+    @Test
+    fun isZeroBeforeStart() = runTest {
+            val countString = timerViewModel.counter.value
+            assertTrue(countString == "00:00:00")
+        }
+
+
+    @Test
+    fun testStartFunction() = runTest {
+        timerViewModel.start()
+        delay(2000) // wait for 2 seconds
+        val isRunning = timerViewModel.isRunning.value
+        val countString = timerViewModel.counter.value
+        assertTrue(isRunning)
+        assertNotEquals("00:00:00", countString) // counter should have increased
+    }
+
+    @Test
+    fun testStopFunction() = runTest {
+        timerViewModel.start()
+        delay(2000) // wait for 2 seconds
+        timerViewModel.stop()
+        val isRunning = timerViewModel.isRunning.value
+        val countString1 = timerViewModel.counter.value
+        delay(2000) // wait for another 2 seconds
+        val countString2 = timerViewModel.counter.value
+        assertFalse(isRunning)
+        assertEquals(countString1, countString2) // counter should not have increased
+    }
+}
+
+fun convertToMilliseconds(time: String): Long {
+    val parts = time.split(":").map { it.toLong() }
+    val hours = parts[0]
+    val minutes = parts[1]
+    val seconds = parts[2]
+    return (hours * 3600 + minutes * 60 + seconds) * 1000
+}

--- a/app/src/androidTest/java/ch/epfl/skysync/viewmodel/TimerViewModelTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/viewmodel/TimerViewModelTest.kt
@@ -4,8 +4,6 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import kotlinx.coroutines.delay
-
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Before
@@ -14,55 +12,48 @@ import org.junit.Test
 
 class TimerViewModelTest {
 
-    @get:Rule
-    val composeTestRule = createComposeRule()
-    lateinit var timerViewModel: TimerViewModel
+  @get:Rule val composeTestRule = createComposeRule()
+  lateinit var timerViewModel: TimerViewModel
 
-    @Before
-    fun setUp() {
-        composeTestRule.setContent {
-            timerViewModel = TimerViewModel.createViewModel()
-            val countString by timerViewModel.counter.collectAsStateWithLifecycle()
-            Text(countString)
-        }
+  @Before
+  fun setUp() {
+    composeTestRule.setContent {
+      timerViewModel = TimerViewModel.createViewModel()
+      val countString by timerViewModel.counter.collectAsStateWithLifecycle()
+      Text(countString)
     }
+  }
 
+  @Test
+  fun isZeroBeforeStart() = runTest {
+    val countString = timerViewModel.counter.value
+    assertTrue(countString == "00:00:00")
+  }
 
-    @Test
-    fun isZeroBeforeStart() = runTest {
-            val countString = timerViewModel.counter.value
-            assertTrue(countString == "00:00:00")
-        }
-
-
-    @Test
-    fun testStartFunction() = runTest {
-        timerViewModel.start()
-        delay(2000) // wait for 2 seconds
-        val isRunning = timerViewModel.isRunning.value
-        val countString = timerViewModel.counter.value
-        assertTrue(isRunning)
-        assertNotEquals("00:00:00", countString) // counter should have increased
+  @Test
+  fun testStartFunction() {
+    timerViewModel.start()
+    composeTestRule.waitUntil(timeoutMillis = 1500) {
+      val countString = timerViewModel.counter.value
+      countString == "00:00:01"
     }
+    val isRunning = timerViewModel.isRunning.value
+    assertTrue(isRunning)
+    val currentCount = timerViewModel.counter.value
+    assertTrue(currentCount == "00:00:01")
+  }
 
-    @Test
-    fun testStopFunction() = runTest {
-        timerViewModel.start()
-        delay(2000) // wait for 2 seconds
-        timerViewModel.stop()
-        val isRunning = timerViewModel.isRunning.value
-        val countString1 = timerViewModel.counter.value
-        delay(2000) // wait for another 2 seconds
-        val countString2 = timerViewModel.counter.value
-        assertFalse(isRunning)
-        assertEquals(countString1, countString2) // counter should not have increased
+  @Test
+  fun testStopFunction() = runTest {
+    timerViewModel.start()
+    composeTestRule.waitUntil(timeoutMillis = 2500) {
+      val countString = timerViewModel.counter.value
+      countString == "00:00:02"
     }
-}
-
-fun convertToMilliseconds(time: String): Long {
-    val parts = time.split(":").map { it.toLong() }
-    val hours = parts[0]
-    val minutes = parts[1]
-    val seconds = parts[2]
-    return (hours * 3600 + minutes * 60 + seconds) * 1000
+    timerViewModel.stop()
+    val isRunning = timerViewModel.isRunning.value
+    assertFalse(isRunning)
+    val currentCount = timerViewModel.counter.value
+    assertTrue(currentCount == "00:00:02")
+  }
 }

--- a/app/src/main/java/ch/epfl/skysync/MainActivity.kt
+++ b/app/src/main/java/ch/epfl/skysync/MainActivity.kt
@@ -49,7 +49,7 @@ class MainActivity : ComponentActivity() {
       SkySyncTheme {
         val navController = rememberNavController()
         Scaffold(snackbarHost = { GlobalSnackbarHost() }) {
-          val timerVm = TimerViewModel.createViewModel()
+          val timerVm = TimerViewModel.createViewModel() // is shared between all screens
           MainGraph(
               repository = repository,
               navHostController = navController,

--- a/app/src/main/java/ch/epfl/skysync/MainActivity.kt
+++ b/app/src/main/java/ch/epfl/skysync/MainActivity.kt
@@ -14,6 +14,7 @@ import ch.epfl.skysync.components.SnackbarManager
 import ch.epfl.skysync.database.FirestoreDatabase
 import ch.epfl.skysync.navigation.MainGraph
 import ch.epfl.skysync.ui.theme.SkySyncTheme
+import ch.epfl.skysync.viewmodel.TimerViewModel
 import com.firebase.ui.auth.FirebaseAuthUIActivityResultContract
 import com.firebase.ui.auth.data.model.FirebaseAuthUIAuthenticationResult
 import com.google.firebase.auth.FirebaseAuth
@@ -48,11 +49,14 @@ class MainActivity : ComponentActivity() {
       SkySyncTheme {
         val navController = rememberNavController()
         Scaffold(snackbarHost = { GlobalSnackbarHost() }) {
+          val timerVm = TimerViewModel.createViewModel()
           MainGraph(
               repository = repository,
               navHostController = navController,
               signInLauncher = signInLauncher,
-              uid = user.value?.uid)
+              uid = user.value?.uid,
+              timer=timerVm,
+            )
         }
       }
     }

--- a/app/src/main/java/ch/epfl/skysync/MainActivity.kt
+++ b/app/src/main/java/ch/epfl/skysync/MainActivity.kt
@@ -55,8 +55,8 @@ class MainActivity : ComponentActivity() {
               navHostController = navController,
               signInLauncher = signInLauncher,
               uid = user.value?.uid,
-              timer=timerVm,
-            )
+              timer = timerVm,
+          )
         }
       }
     }

--- a/app/src/main/java/ch/epfl/skysync/components/Timer.kt
+++ b/app/src/main/java/ch/epfl/skysync/components/Timer.kt
@@ -22,41 +22,36 @@ import ch.epfl.skysync.ui.theme.lightOrange
 import kotlinx.coroutines.delay
 
 @Composable
-fun Timer(modifier: Modifier) {
-  var timer by remember { mutableIntStateOf(0) }
-  var isRunning by remember { mutableStateOf(false) }
+fun Timer(modifier: Modifier,
+          currentTimer: String,
+          isRunning: Boolean,
+          onStart: () -> Unit,
+          onStop: () -> Unit)
+{
   Box(
       modifier = modifier.testTag("Timer"),
       contentAlignment = androidx.compose.ui.Alignment.Center) {
         Column(horizontalAlignment = androidx.compose.ui.Alignment.CenterHorizontally) {
           Text(
               modifier = Modifier.testTag("Timer Value"),
-              text = timer.formatTime(),
+              text = currentTimer,
               style = MaterialTheme.typography.headlineMedium)
           if (isRunning) {
             Button(
                 modifier = Modifier.testTag("Reset Button"),
                 onClick = {
-                  isRunning = !isRunning
-                  timer = 0
+                    onStop()
                 }) {
-                  Text(text = "Reset")
+                  Text(text = "Stop Flight")
                 }
           } else {
             Button(
                 modifier = Modifier.testTag("Start Button"),
-                onClick = { isRunning = !isRunning },
+                onClick = {
+                    onStart()},
                 colors = ButtonDefaults.buttonColors(containerColor = lightOrange)) {
-                  Text(text = "Start")
+                  Text(text = "Start Flight")
                 }
-          }
-          if (isRunning) {
-            LaunchedEffect(key1 = isRunning) {
-              while (isRunning) {
-                delay(1000)
-                timer++
-              }
-            }
           }
         }
       }
@@ -73,5 +68,5 @@ fun Int.formatTime(): String {
 @Preview
 @Composable
 fun TimerPreview() {
-  Timer(Modifier.padding(16.dp))
+  Timer(Modifier.padding(16.dp), "0:0:0", false, {}, {})
 }

--- a/app/src/main/java/ch/epfl/skysync/components/Timer.kt
+++ b/app/src/main/java/ch/epfl/skysync/components/Timer.kt
@@ -16,6 +16,16 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import ch.epfl.skysync.ui.theme.lightOrange
 
+/**
+ * Timer composable that displays the current timer value and a button to start (if the timer is
+ * currently not running) or stop (if the timer is currently running).
+ *
+ * @param modifier Modifier to apply to this layout node.
+ * @param currentTimer The current value of the timer.
+ * @param isRunning The current state of the timer.
+ * @param onStart Callback to start the timer.
+ * @param onStop Callback to stop the timer.
+ */
 @Composable
 fun Timer(
     modifier: Modifier,

--- a/app/src/main/java/ch/epfl/skysync/components/Timer.kt
+++ b/app/src/main/java/ch/epfl/skysync/components/Timer.kt
@@ -8,26 +8,22 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import ch.epfl.skysync.ui.theme.lightOrange
-import kotlinx.coroutines.delay
 
 @Composable
-fun Timer(modifier: Modifier,
-          currentTimer: String,
-          isRunning: Boolean,
-          onStart: () -> Unit,
-          onStop: () -> Unit)
-{
+fun Timer(
+    modifier: Modifier,
+    currentTimer: String,
+    isRunning: Boolean,
+    onStart: () -> Unit,
+    onStop: () -> Unit
+) {
   Box(
       modifier = modifier.testTag("Timer"),
       contentAlignment = androidx.compose.ui.Alignment.Center) {
@@ -37,32 +33,19 @@ fun Timer(modifier: Modifier,
               text = currentTimer,
               style = MaterialTheme.typography.headlineMedium)
           if (isRunning) {
-            Button(
-                modifier = Modifier.testTag("Reset Button"),
-                onClick = {
-                    onStop()
-                }) {
-                  Text(text = "Stop Flight")
-                }
+            Button(modifier = Modifier.testTag("Stop Button"), onClick = { onStop() }) {
+              Text(text = "Stop Flight")
+            }
           } else {
             Button(
                 modifier = Modifier.testTag("Start Button"),
-                onClick = {
-                    onStart()},
+                onClick = { onStart() },
                 colors = ButtonDefaults.buttonColors(containerColor = lightOrange)) {
                   Text(text = "Start Flight")
                 }
           }
         }
       }
-}
-
-// Format the time in HH:MM:SS format from seconds
-fun Int.formatTime(): String {
-  val hours = this / 3600
-  val minutes = (this % 3600) / 60
-  val remainingSeconds = this % 60
-  return String.format("%02d:%02d:%02d", hours, minutes, remainingSeconds)
 }
 
 @Preview

--- a/app/src/main/java/ch/epfl/skysync/navigation/HomeGraph.kt
+++ b/app/src/main/java/ch/epfl/skysync/navigation/HomeGraph.kt
@@ -49,9 +49,7 @@ fun NavGraphBuilder.homeGraph(
           ChatViewModel.createViewModel(uid!!, messageListenerSharedViewModel, repository)
       ChatScreen(navController, chatViewModel)
     }
-    composable(Route.FLIGHT) {
-        FlightScreen(navController, timer!!)
-    }
+    composable(Route.FLIGHT) { FlightScreen(navController, timer!!) }
     composable(Route.HOME) { entry ->
 
       // get the MessageListenerSharedViewModel here so that it gets

--- a/app/src/main/java/ch/epfl/skysync/navigation/HomeGraph.kt
+++ b/app/src/main/java/ch/epfl/skysync/navigation/HomeGraph.kt
@@ -29,12 +29,14 @@ import ch.epfl.skysync.screens.flightDetail.FlightDetailScreen
 import ch.epfl.skysync.viewmodel.ChatViewModel
 import ch.epfl.skysync.viewmodel.FlightsViewModel
 import ch.epfl.skysync.viewmodel.MessageListenerSharedViewModel
+import ch.epfl.skysync.viewmodel.TimerViewModel
 
 /** Graph of the main screens of the app */
 fun NavGraphBuilder.homeGraph(
     repository: Repository,
     navController: NavHostController,
-    uid: String?
+    uid: String?,
+    timer: TimerViewModel
 ) {
   navigation(startDestination = Route.HOME, route = Route.MAIN) {
     personalCalendar(repository, navController, uid)
@@ -47,7 +49,9 @@ fun NavGraphBuilder.homeGraph(
           ChatViewModel.createViewModel(uid!!, messageListenerSharedViewModel, repository)
       ChatScreen(navController, chatViewModel)
     }
-    composable(Route.FLIGHT) { FlightScreen(navController) }
+    composable(Route.FLIGHT) {
+        FlightScreen(navController, timer)
+    }
     composable(Route.HOME) { entry ->
 
       // get the MessageListenerSharedViewModel here so that it gets

--- a/app/src/main/java/ch/epfl/skysync/navigation/HomeGraph.kt
+++ b/app/src/main/java/ch/epfl/skysync/navigation/HomeGraph.kt
@@ -36,7 +36,7 @@ fun NavGraphBuilder.homeGraph(
     repository: Repository,
     navController: NavHostController,
     uid: String?,
-    timer: TimerViewModel
+    timer: TimerViewModel? = null
 ) {
   navigation(startDestination = Route.HOME, route = Route.MAIN) {
     personalCalendar(repository, navController, uid)
@@ -50,7 +50,7 @@ fun NavGraphBuilder.homeGraph(
       ChatScreen(navController, chatViewModel)
     }
     composable(Route.FLIGHT) {
-        FlightScreen(navController, timer)
+        FlightScreen(navController, timer!!)
     }
     composable(Route.HOME) { entry ->
 

--- a/app/src/main/java/ch/epfl/skysync/navigation/MainGraph.kt
+++ b/app/src/main/java/ch/epfl/skysync/navigation/MainGraph.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import ch.epfl.skysync.Repository
 import ch.epfl.skysync.screens.LoginScreen
+import ch.epfl.skysync.viewmodel.TimerViewModel
 
 /** Graph of the whole navigation of the app */
 @Composable
@@ -15,12 +16,18 @@ fun MainGraph(
     repository: Repository,
     navHostController: NavHostController,
     signInLauncher: ActivityResultLauncher<Intent>,
-    uid: String?
+    uid: String?,
+    timer: TimerViewModel
 ) {
   NavHost(
       navController = navHostController,
       startDestination = if (uid == null) Route.LOGIN else Route.MAIN) {
-        homeGraph(repository, navHostController, uid)
+        homeGraph(
+            repository,
+            navHostController,
+            uid,
+            timer
+        )
         composable(Route.LOGIN) { LoginScreen(signInLauncher = signInLauncher) }
       }
 }

--- a/app/src/main/java/ch/epfl/skysync/navigation/MainGraph.kt
+++ b/app/src/main/java/ch/epfl/skysync/navigation/MainGraph.kt
@@ -22,12 +22,7 @@ fun MainGraph(
   NavHost(
       navController = navHostController,
       startDestination = if (uid == null) Route.LOGIN else Route.MAIN) {
-        homeGraph(
-            repository,
-            navHostController,
-            uid,
-            timer
-        )
+        homeGraph(repository, navHostController, uid, timer)
         composable(Route.LOGIN) { LoginScreen(signInLauncher = signInLauncher) }
       }
 }

--- a/app/src/main/java/ch/epfl/skysync/screens/Flight.kt
+++ b/app/src/main/java/ch/epfl/skysync/screens/Flight.kt
@@ -67,8 +67,8 @@ fun FlightScreen(navController: NavHostController, timer: TimerViewModel) {
   // Access to the application context.
   val context = LocalContext.current
 
-    val currentTime by timer.counter.collectAsStateWithLifecycle()
-    val flightIsStarted by timer.isRunning.collectAsStateWithLifecycle()
+  val currentTime by timer.counter.collectAsStateWithLifecycle()
+  val flightIsStarted by timer.isRunning.collectAsStateWithLifecycle()
 
   // Manages the state of location permissions.
   val locationPermission = rememberPermissionState(android.Manifest.permission.ACCESS_FINE_LOCATION)
@@ -161,19 +161,15 @@ fun FlightScreen(navController: NavHostController, timer: TimerViewModel) {
         if (locationPermission.status.isGranted) {
           Box(
               modifier =
-              Modifier
-                  .fillMaxSize()
-                  .padding(start = 32.dp, bottom = 88.dp, top = 100.dp),
+                  Modifier.fillMaxSize().padding(start = 32.dp, bottom = 88.dp, top = 100.dp),
               contentAlignment = Alignment.BottomStart) {
                 Timer(
-                    Modifier
-                        .align(Alignment.TopEnd)
-                        .testTag("Timer"),
+                    Modifier.align(Alignment.TopEnd).testTag("Timer"),
                     currentTimer = currentTime,
                     isRunning = flightIsStarted,
                     onStart = { timer.start() },
                     onStop = { timer.stop() },
-                    )
+                )
 
                 Row(
                     horizontalArrangement = Arrangement.SpaceBetween,
@@ -214,10 +210,7 @@ fun FlightScreen(navController: NavHostController, timer: TimerViewModel) {
         // Renders the Google Map or a permission request message based on the permission status.
         if (locationPermission.status.isGranted && location != null) {
           GoogleMap(
-              modifier = Modifier
-                  .fillMaxSize()
-                  .padding(padding)
-                  .testTag("Map"),
+              modifier = Modifier.fillMaxSize().padding(padding).testTag("Map"),
               cameraPositionState = cameraPositionState) {
                 Marker(state = markerState, title = "Your Location", snippet = "You are here")
               }
@@ -226,17 +219,14 @@ fun FlightScreen(navController: NavHostController, timer: TimerViewModel) {
                   "X Speed: $speed m/s\nY Speed: $verticalSpeed m/s\nAltitude: $altitude m\nBearing: $bearing °",
               style = MaterialTheme.typography.bodyLarge,
               modifier =
-              Modifier
-                  .padding(top = 16.dp, start = 12.dp, end = 12.dp)
-                  .background(color = Color.White, shape = RoundedCornerShape(8.dp))
-                  .padding(6.dp))
+                  Modifier.padding(top = 16.dp, start = 12.dp, end = 12.dp)
+                      .background(color = Color.White, shape = RoundedCornerShape(8.dp))
+                      .padding(6.dp))
         }
         if (!locationPermission.status.isGranted) {
           // Displays a message if location permission is denied.
           Box(
-              modifier = Modifier
-                  .fillMaxSize()
-                  .padding(16.dp),
+              modifier = Modifier.fillMaxSize().padding(16.dp),
               contentAlignment = Alignment.Center) {
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                   Text("Access to location is required to use this feature.")

--- a/app/src/main/java/ch/epfl/skysync/screens/Flight.kt
+++ b/app/src/main/java/ch/epfl/skysync/screens/Flight.kt
@@ -31,12 +31,14 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import ch.epfl.skysync.components.LoadingComponent
 import ch.epfl.skysync.components.Timer
 import ch.epfl.skysync.navigation.BottomBar
 import ch.epfl.skysync.ui.theme.lightOrange
+import ch.epfl.skysync.viewmodel.TimerViewModel
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
@@ -61,9 +63,12 @@ import com.google.maps.android.compose.rememberMarkerState
  */
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
-fun FlightScreen(navController: NavHostController) {
+fun FlightScreen(navController: NavHostController, timer: TimerViewModel) {
   // Access to the application context.
   val context = LocalContext.current
+
+    val currentTime by timer.counter.collectAsStateWithLifecycle()
+    val flightIsStarted by timer.isRunning.collectAsStateWithLifecycle()
 
   // Manages the state of location permissions.
   val locationPermission = rememberPermissionState(android.Manifest.permission.ACCESS_FINE_LOCATION)
@@ -156,9 +161,20 @@ fun FlightScreen(navController: NavHostController) {
         if (locationPermission.status.isGranted) {
           Box(
               modifier =
-                  Modifier.fillMaxSize().padding(start = 32.dp, bottom = 88.dp, top = 100.dp),
+              Modifier
+                  .fillMaxSize()
+                  .padding(start = 32.dp, bottom = 88.dp, top = 100.dp),
               contentAlignment = Alignment.BottomStart) {
-                Timer(Modifier.align(Alignment.TopEnd).testTag("Timer"))
+                Timer(
+                    Modifier
+                        .align(Alignment.TopEnd)
+                        .testTag("Timer"),
+                    currentTimer = currentTime,
+                    isRunning = flightIsStarted,
+                    onStart = { timer.start() },
+                    onStop = { timer.stop() },
+                    )
+
                 Row(
                     horizontalArrangement = Arrangement.SpaceBetween,
                     modifier = Modifier.fillMaxWidth()) {
@@ -198,7 +214,10 @@ fun FlightScreen(navController: NavHostController) {
         // Renders the Google Map or a permission request message based on the permission status.
         if (locationPermission.status.isGranted && location != null) {
           GoogleMap(
-              modifier = Modifier.fillMaxSize().padding(padding).testTag("Map"),
+              modifier = Modifier
+                  .fillMaxSize()
+                  .padding(padding)
+                  .testTag("Map"),
               cameraPositionState = cameraPositionState) {
                 Marker(state = markerState, title = "Your Location", snippet = "You are here")
               }
@@ -207,14 +226,17 @@ fun FlightScreen(navController: NavHostController) {
                   "X Speed: $speed m/s\nY Speed: $verticalSpeed m/s\nAltitude: $altitude m\nBearing: $bearing °",
               style = MaterialTheme.typography.bodyLarge,
               modifier =
-                  Modifier.padding(top = 16.dp, start = 12.dp, end = 12.dp)
-                      .background(color = Color.White, shape = RoundedCornerShape(8.dp))
-                      .padding(6.dp))
+              Modifier
+                  .padding(top = 16.dp, start = 12.dp, end = 12.dp)
+                  .background(color = Color.White, shape = RoundedCornerShape(8.dp))
+                  .padding(6.dp))
         }
         if (!locationPermission.status.isGranted) {
           // Displays a message if location permission is denied.
           Box(
-              modifier = Modifier.fillMaxSize().padding(16.dp),
+              modifier = Modifier
+                  .fillMaxSize()
+                  .padding(16.dp),
               contentAlignment = Alignment.Center) {
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                   Text("Access to location is required to use this feature.")
@@ -229,5 +251,5 @@ fun FlightScreen(navController: NavHostController) {
 @Preview
 fun FlightScreenPreview() {
   val navController = rememberNavController()
-  FlightScreen(navController = navController)
+  FlightScreen(navController = navController, timer = TimerViewModel())
 }

--- a/app/src/main/java/ch/epfl/skysync/viewmodel/TimerViewModel.kt
+++ b/app/src/main/java/ch/epfl/skysync/viewmodel/TimerViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.compose.viewModel
-import ch.epfl.skysync.components.formatTime
 import ch.epfl.skysync.util.WhileUiSubscribed
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -15,67 +14,65 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
+class TimerViewModel : ViewModel() {
+  private val _isRunning = MutableStateFlow(false)
+  val isRunning = _isRunning.asStateFlow()
 
-class TimerViewModel: ViewModel(){
-    private val _isRunning = MutableStateFlow(false)
-    val isRunning = _isRunning.asStateFlow()
+  private var job: Job? = null
+  private var lastTimestamp = 0L
+  private val _counter = MutableStateFlow(0L)
+  val counter =
+      _counter
+          .map { formatTime(it) }
+          .stateIn(viewModelScope, started = WhileUiSubscribed, initialValue = formatTime(0))
 
-    private var job: Job? = null
-    private var lastTimestamp = 0L
-    private val _counter = MutableStateFlow(0L)
-    val counter = _counter.map {
-        formatTime(it)
-    }.stateIn(viewModelScope, started=WhileUiSubscribed, initialValue = formatTime(0) )
+  companion object {
+    @Composable
+    fun createViewModel(): TimerViewModel {
+      return viewModel<TimerViewModel>(
+          factory =
+              object : ViewModelProvider.Factory {
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                  return TimerViewModel() as T
+                }
+              })
+    }
+  }
 
-    companion object {
-        @Composable
-        fun createViewModel(): TimerViewModel {
-            return viewModel<TimerViewModel>(
-                factory =
-                object : ViewModelProvider.Factory {
-                    override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                        return TimerViewModel() as T
-                    }
-                })
+  fun start() {
+    if (_isRunning.value) return
+    _counter.value = 0L
+    _isRunning.value = true
+    var newTimeStamp = 0L
+    job =
+        viewModelScope.launch {
+          lastTimestamp = System.currentTimeMillis()
+          while (_isRunning.value) {
+            delay(100)
+            newTimeStamp = System.currentTimeMillis()
+            _counter.value += newTimeStamp - lastTimestamp
+            lastTimestamp = newTimeStamp
+          }
         }
-    }
+  }
 
-    fun start() {
-        if (_isRunning.value) return
-        _counter.value = 0L
-        _isRunning.value = true
-        var newTimeStamp = 0L
-        job = viewModelScope.launch {
-            lastTimestamp = System.currentTimeMillis()
-            while (_isRunning.value){
-                delay(100)
-                newTimeStamp = System.currentTimeMillis()
-                _counter.value += newTimeStamp - lastTimestamp
-                lastTimestamp = newTimeStamp
-            }
-        }
-    }
+  private fun formatTime(milliseconds: Long): String {
+    val secondsRounded = milliseconds / 1000
+    val hours = secondsRounded / 3600
+    val minutes = (secondsRounded % 3600) / 60
+    val remainingSeconds = secondsRounded % 60
+    return String.format("%02d:%02d:%02d", hours, minutes, remainingSeconds)
+  }
 
-    private fun formatTime(milliseconds: Long): String {
-        val secondsRounded = milliseconds / 1000
-        val hours = secondsRounded / 3600
-        val minutes = (secondsRounded % 3600) / 60
-        val remainingSeconds = secondsRounded % 60
-        return String.format("%02d:%02d:%02d", hours, minutes, remainingSeconds)
-    }
+  fun stop() {
+    _isRunning.value = false
+    job?.cancel()
+    job = null
+    lastTimestamp = 0L
+  }
 
-    fun stop() {
-        _isRunning.value = false
-        job?.cancel()
-        job = null
-        lastTimestamp = 0L
-    }
-
-
-
-    override fun onCleared() {
-        super.onCleared()
-        stop()
-    }
-
+  override fun onCleared() {
+    super.onCleared()
+    stop()
+  }
 }

--- a/app/src/main/java/ch/epfl/skysync/viewmodel/TimerViewModel.kt
+++ b/app/src/main/java/ch/epfl/skysync/viewmodel/TimerViewModel.kt
@@ -1,0 +1,81 @@
+package ch.epfl.skysync.viewmodel
+
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.compose.viewModel
+import ch.epfl.skysync.components.formatTime
+import ch.epfl.skysync.util.WhileUiSubscribed
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+
+class TimerViewModel: ViewModel(){
+    private val _isRunning = MutableStateFlow(false)
+    val isRunning = _isRunning.asStateFlow()
+
+    private var job: Job? = null
+    private var lastTimestamp = 0L
+    private val _counter = MutableStateFlow(0L)
+    val counter = _counter.map {
+        formatTime(it)
+    }.stateIn(viewModelScope, started=WhileUiSubscribed, initialValue = formatTime(0) )
+
+    companion object {
+        @Composable
+        fun createViewModel(): TimerViewModel {
+            return viewModel<TimerViewModel>(
+                factory =
+                object : ViewModelProvider.Factory {
+                    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                        return TimerViewModel() as T
+                    }
+                })
+        }
+    }
+
+    fun start() {
+        if (_isRunning.value) return
+        _isRunning.value = true
+        var newTimeStamp = 0L
+        job = viewModelScope.launch {
+            lastTimestamp = System.currentTimeMillis()
+            while (_isRunning.value){
+                delay(100)
+                newTimeStamp = System.currentTimeMillis()
+                _counter.value += newTimeStamp - lastTimestamp
+                lastTimestamp = newTimeStamp
+            }
+        }
+    }
+
+    fun formatTime(milliseconds: Long): String {
+        val secondsRounded = milliseconds / 1000
+        val hours = secondsRounded / 3600
+        val minutes = (secondsRounded % 3600) / 60
+        val remainingSeconds = secondsRounded % 60
+        return String.format("%02d:%02d:%02d", hours, minutes, remainingSeconds)
+    }
+
+    fun stop() {
+        _isRunning.value = false
+        job?.cancel()
+        job = null
+        _counter.value = 0L
+        lastTimestamp = 0L
+    }
+
+
+
+    override fun onCleared() {
+        super.onCleared()
+        stop()
+    }
+
+}

--- a/app/src/main/java/ch/epfl/skysync/viewmodel/TimerViewModel.kt
+++ b/app/src/main/java/ch/epfl/skysync/viewmodel/TimerViewModel.kt
@@ -42,6 +42,7 @@ class TimerViewModel: ViewModel(){
 
     fun start() {
         if (_isRunning.value) return
+        _counter.value = 0L
         _isRunning.value = true
         var newTimeStamp = 0L
         job = viewModelScope.launch {
@@ -55,7 +56,7 @@ class TimerViewModel: ViewModel(){
         }
     }
 
-    fun formatTime(milliseconds: Long): String {
+    private fun formatTime(milliseconds: Long): String {
         val secondsRounded = milliseconds / 1000
         val hours = secondsRounded / 3600
         val minutes = (secondsRounded % 3600) / 60
@@ -67,7 +68,6 @@ class TimerViewModel: ViewModel(){
         _isRunning.value = false
         job?.cancel()
         job = null
-        _counter.value = 0L
         lastTimestamp = 0L
     }
 

--- a/app/src/main/java/ch/epfl/skysync/viewmodel/TimerViewModel.kt
+++ b/app/src/main/java/ch/epfl/skysync/viewmodel/TimerViewModel.kt
@@ -14,19 +14,25 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
+/** ViewModel for the Timer composable. */
 class TimerViewModel : ViewModel() {
   private val _isRunning = MutableStateFlow(false)
+
+  /** The current state of the timer. */
   val isRunning = _isRunning.asStateFlow()
 
   private var job: Job? = null
   private var lastTimestamp = 0L
   private val _counter = MutableStateFlow(0L)
+
+  /** The current value of the counter formatted as a string in the format "HH:MM:SS". */
   val counter =
       _counter
           .map { formatTime(it) }
           .stateIn(viewModelScope, started = WhileUiSubscribed, initialValue = formatTime(0))
 
   companion object {
+    /** return a new instance of TimerViewModel */
     @Composable
     fun createViewModel(): TimerViewModel {
       return viewModel<TimerViewModel>(
@@ -39,6 +45,10 @@ class TimerViewModel : ViewModel() {
     }
   }
 
+  /**
+   * Starts the timer on a reset counter in a new coroutine and sets isRunning to true. Uses
+   * timestamp to update the counter every approx. 100ms.
+   */
   fun start() {
     if (_isRunning.value) return
     _counter.value = 0L
@@ -56,6 +66,7 @@ class TimerViewModel : ViewModel() {
         }
   }
 
+  /** Formats the given time in milliseconds to a string in the format "HH:MM:SS". */
   private fun formatTime(milliseconds: Long): String {
     val secondsRounded = milliseconds / 1000
     val hours = secondsRounded / 3600
@@ -64,6 +75,10 @@ class TimerViewModel : ViewModel() {
     return String.format("%02d:%02d:%02d", hours, minutes, remainingSeconds)
   }
 
+  /**
+   * Stops the timer by setting isRunning to false and cancelling the coroutine that updates the
+   * counter. The time is not reset.
+   */
   fun stop() {
     _isRunning.value = false
     job?.cancel()


### PR DESCRIPTION
closes #222

# started counter continues running when flight screen is left
- added `TimerViewMode` to wrap the timer related information
- the timer viewmodel is initiated on the MainActivity level as a first solution
- > timer must continue running in the back even if we leave the Flight screen. However, the flight screen is the only screen that actually accesses the variables of the `TimerViewModel` hence I decided against a shared viewmodel implementation strategy. 


# increased precision of counter
- on start:  a coroutine updates the counter (miliseconds) with a delay of 100ms
- uses now timestamp based computations instead of simply increasing the timer with delays since the delays are not exact and depend on the scheduler + the current workload
- 