### PR TITLE
Synch personal flights calendar

### DIFF
--- a/app/src/androidTest/java/ch/epfl/skysync/ConfirmFlightScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/ConfirmFlightScreenTest.kt
@@ -55,6 +55,7 @@ class ConfirmFlightScreenTest {
       nodes[i].performClick()
       var route = navController.currentBackStackEntry?.destination?.route
       Assert.assertEquals(Route.FLIGHT_DETAILS + "/{Flight ID}", route)
+
       composeTestRule.onNodeWithText("Confirm").performClick()
       composeTestRule.waitForIdle()
       route = navController.currentBackStackEntry?.destination?.route
@@ -63,7 +64,7 @@ class ConfirmFlightScreenTest {
           .onNodeWithTag("LazyList")
           .performScrollToNode(hasText("Confirm"))
           .assertIsDisplayed()
-      composeTestRule.onNodeWithText("Confirm").performClick()
+      composeTestRule.onNodeWithTag("ConfirmThisFlightButton").performClick()
       composeTestRule.waitForIdle()
       route = navController.currentBackStackEntry?.destination?.route
       Assert.assertEquals(Route.HOME, route)

--- a/app/src/androidTest/java/ch/epfl/skysync/database/DatabaseSetup.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/database/DatabaseSetup.kt
@@ -224,6 +224,17 @@ class DatabaseSetup {
           meetupTimePassenger = LocalTime.of(14, 0, 0),
           meetupLocationPassenger = "location",
       )
+    var flight5 =
+        PlannedFlight(
+            nPassengers = 4,
+            team = Team(roles = listOf(Role(RoleType.PILOT, pilot2), Role(RoleType.CREW, crew2))),
+            flightType = flightType1,
+            balloon = balloon2,
+            basket = basket2,
+            date = LocalDate.now(),
+            timeSlot = TimeSlot.PM,
+            vehicles = listOf(vehicle2, vehicle3),
+            id = UNSET_ID)
 
   var messageGroup1 =
       MessageGroup(name = "Group 1", userIds = setOf(admin2.id, pilot1.id, crew1.id))
@@ -376,7 +387,6 @@ class DatabaseSetup {
         )
     flight2 =
         flight2.copy(
-            date = LocalDate.now(),
             team =
                 Team(
                     roles =
@@ -411,6 +421,20 @@ class DatabaseSetup {
             basket = basket1,
             vehicles = listOf(vehicle2),
         )
+      flight5 =
+          flight5.copy(
+              team =
+              Team(
+                  roles =
+                  listOf(Role(RoleType.PILOT, pilot2), Role(RoleType.CREW, crew2)).sortedBy {
+                          role: Role ->
+                      role.roleType
+                  }),
+              flightType = flightType1,
+              balloon = balloon2,
+              basket = basket2,
+              vehicles = listOf(vehicle2, vehicle3),
+          )
 
     // now that the IDs are set, add the flights/messages
     listOf(
@@ -418,6 +442,7 @@ class DatabaseSetup {
             launch { flight2 = flight2.copy(id = flightTable.add(flight2)) },
             launch { flight3 = flight3.copy(id = flightTable.add(flight3)) },
             launch { flight4 = flight4.copy(id = flightTable.add(flight4)) },
+            launch { flight5 = flight5.copy(id = flightTable.add(flight5)) },
             launch { message1 = message1.copy(id = messageTable.add(messageGroup1.id, message1)) },
             launch { message2 = message2.copy(id = messageTable.add(messageGroup1.id, message2)) },
             launch { message3 = message3.copy(id = messageTable.add(messageGroup2.id, message3)) },

--- a/app/src/androidTest/java/ch/epfl/skysync/database/DatabaseSetup.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/database/DatabaseSetup.kt
@@ -224,17 +224,17 @@ class DatabaseSetup {
           meetupTimePassenger = LocalTime.of(14, 0, 0),
           meetupLocationPassenger = "location",
       )
-    var flight5 =
-        PlannedFlight(
-            nPassengers = 4,
-            team = Team(roles = listOf(Role(RoleType.PILOT, pilot2), Role(RoleType.CREW, crew2))),
-            flightType = flightType1,
-            balloon = balloon2,
-            basket = basket2,
-            date = LocalDate.now(),
-            timeSlot = TimeSlot.PM,
-            vehicles = listOf(vehicle2, vehicle3),
-            id = UNSET_ID)
+  var flight5 =
+      PlannedFlight(
+          nPassengers = 4,
+          team = Team(roles = listOf(Role(RoleType.PILOT, pilot2), Role(RoleType.CREW, crew2))),
+          flightType = flightType1,
+          balloon = balloon2,
+          basket = basket2,
+          date = LocalDate.now(),
+          timeSlot = TimeSlot.PM,
+          vehicles = listOf(vehicle2, vehicle3),
+          id = UNSET_ID)
 
   var messageGroup1 =
       MessageGroup(name = "Group 1", userIds = setOf(admin2.id, pilot1.id, crew1.id))
@@ -421,20 +421,20 @@ class DatabaseSetup {
             basket = basket1,
             vehicles = listOf(vehicle2),
         )
-      flight5 =
-          flight5.copy(
-              team =
-              Team(
-                  roles =
-                  listOf(Role(RoleType.PILOT, pilot2), Role(RoleType.CREW, crew2)).sortedBy {
-                          role: Role ->
-                      role.roleType
-                  }),
-              flightType = flightType1,
-              balloon = balloon2,
-              basket = basket2,
-              vehicles = listOf(vehicle2, vehicle3),
-          )
+    flight5 =
+        flight5.copy(
+            team =
+                Team(
+                    roles =
+                        listOf(Role(RoleType.PILOT, pilot2), Role(RoleType.CREW, crew2)).sortedBy {
+                            role: Role ->
+                          role.roleType
+                        }),
+            flightType = flightType1,
+            balloon = balloon2,
+            basket = basket2,
+            vehicles = listOf(vehicle2, vehicle3),
+        )
 
     // now that the IDs are set, add the flights/messages
     listOf(

--- a/app/src/androidTest/java/ch/epfl/skysync/database/DatabaseSetup.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/database/DatabaseSetup.kt
@@ -376,6 +376,7 @@ class DatabaseSetup {
         )
     flight2 =
         flight2.copy(
+            date = LocalDate.now(),
             team =
                 Team(
                     roles =

--- a/app/src/androidTest/java/ch/epfl/skysync/database/tables/FlightTableUnitTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/database/tables/FlightTableUnitTest.kt
@@ -61,9 +61,9 @@ class FlightTableUnitTest {
 
     val flights = flightTable.getAll(onError = { assertNull(it) })
 
-    assertEquals(6, flightMembers.size)
+    assertEquals(8, flightMembers.size)
     assertEquals(
-        listOf(dbs.flight2, dbs.flight3, dbs.flight4).sortedBy { f -> f.id },
+        listOf(dbs.flight2, dbs.flight3, dbs.flight4, dbs.flight5).sortedBy { f -> f.id },
         flights.sortedBy { f -> f.id })
   }
 }

--- a/app/src/androidTest/java/ch/epfl/skysync/screens/CalendarIntegrationTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/screens/CalendarIntegrationTest.kt
@@ -13,19 +13,13 @@ import androidx.navigation.testing.TestNavHostController
 import ch.epfl.skysync.Repository
 import ch.epfl.skysync.database.DatabaseSetup
 import ch.epfl.skysync.database.FirestoreDatabase
-import ch.epfl.skysync.database.tables.FlightTable
-import ch.epfl.skysync.models.flight.Role
-import ch.epfl.skysync.models.flight.RoleType
-import ch.epfl.skysync.models.flight.Team
 import ch.epfl.skysync.navigation.Route
 import ch.epfl.skysync.navigation.homeGraph
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import java.time.LocalDate
 
 class CalendarIntegrationTest {
   @get:Rule val composeTestRule = createComposeRule()

--- a/app/src/androidTest/java/ch/epfl/skysync/screens/CalendarIntegrationTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/screens/CalendarIntegrationTest.kt
@@ -1,0 +1,61 @@
+package ch.epfl.skysync.screens
+
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.compose.NavHost
+import androidx.navigation.testing.TestNavHostController
+import ch.epfl.skysync.Repository
+import ch.epfl.skysync.database.DatabaseSetup
+import ch.epfl.skysync.database.FirestoreDatabase
+import ch.epfl.skysync.navigation.Route
+import ch.epfl.skysync.navigation.homeGraph
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class CalendarIntegrationTest {
+  @get:Rule val composeTestRule = createComposeRule()
+  lateinit var navController: TestNavHostController
+  private val db = FirestoreDatabase(useEmulator = true)
+  private val dbs = DatabaseSetup()
+
+  @Before
+  fun setUpNavHost() = runTest {
+    dbs.clearDatabase(db)
+    dbs.fillDatabase(db)
+    composeTestRule.setContent {
+      val repository = Repository(db)
+      navController = TestNavHostController(LocalContext.current)
+      navController.navigatorProvider.addNavigator(ComposeNavigator())
+      NavHost(navController = navController, startDestination = Route.MAIN) {
+        homeGraph(repository, navController, dbs.pilot2.id)
+      }
+    }
+  }
+
+  @Test
+  fun seeAndAccessPersonalFlight() {
+    composeTestRule.waitUntil {
+      val nodes = composeTestRule.onAllNodesWithText("Upcoming flights")
+      nodes.fetchSemanticsNodes().isNotEmpty()
+    }
+    composeTestRule.onNodeWithText("Calendar").performClick()
+    composeTestRule.onNodeWithTag(Route.FLIGHT_CALENDAR).performClick()
+    val route = navController.currentBackStackEntry?.destination?.route
+    Assert.assertEquals(route, Route.FLIGHT_CALENDAR)
+
+    composeTestRule.waitUntil(3000) {
+      val nodes = composeTestRule.onAllNodesWithText(dbs.flight2.flightType.name)
+      nodes.fetchSemanticsNodes().isNotEmpty()
+    }
+    composeTestRule.onNodeWithText(dbs.flight2.flightType.name).assertIsDisplayed()
+  }
+}

--- a/app/src/androidTest/java/ch/epfl/skysync/screens/CalendarIntegrationTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/screens/CalendarIntegrationTest.kt
@@ -13,13 +13,19 @@ import androidx.navigation.testing.TestNavHostController
 import ch.epfl.skysync.Repository
 import ch.epfl.skysync.database.DatabaseSetup
 import ch.epfl.skysync.database.FirestoreDatabase
+import ch.epfl.skysync.database.tables.FlightTable
+import ch.epfl.skysync.models.flight.Role
+import ch.epfl.skysync.models.flight.RoleType
+import ch.epfl.skysync.models.flight.Team
 import ch.epfl.skysync.navigation.Route
 import ch.epfl.skysync.navigation.homeGraph
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import java.time.LocalDate
 
 class CalendarIntegrationTest {
   @get:Rule val composeTestRule = createComposeRule()
@@ -53,9 +59,9 @@ class CalendarIntegrationTest {
     Assert.assertEquals(route, Route.FLIGHT_CALENDAR)
 
     composeTestRule.waitUntil(3000) {
-      val nodes = composeTestRule.onAllNodesWithText(dbs.flight2.flightType.name)
+      val nodes = composeTestRule.onAllNodesWithText(dbs.flight5.flightType.name)
       nodes.fetchSemanticsNodes().isNotEmpty()
     }
-    composeTestRule.onNodeWithText(dbs.flight2.flightType.name).assertIsDisplayed()
+    composeTestRule.onNodeWithText(dbs.flight5.flightType.name).assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/ch/epfl/skysync/viewmodel/CalendarViewModelTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/viewmodel/CalendarViewModelTest.kt
@@ -7,6 +7,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.epfl.skysync.database.DatabaseSetup
 import ch.epfl.skysync.database.FirestoreDatabase
 import ch.epfl.skysync.database.tables.AvailabilityTable
+import ch.epfl.skysync.database.tables.FlightTable
 import ch.epfl.skysync.database.tables.UserTable
 import ch.epfl.skysync.models.calendar.AvailabilityStatus
 import ch.epfl.skysync.models.calendar.TimeSlot
@@ -25,6 +26,7 @@ class CalendarViewModelTest {
   private val dbs = DatabaseSetup()
   private val userTable = UserTable(db)
   private val availabilityTable = AvailabilityTable(db)
+  private val flightTable = FlightTable(db)
   private lateinit var calendarViewModel: CalendarViewModel
 
   @Before
@@ -33,7 +35,8 @@ class CalendarViewModelTest {
     dbs.fillDatabase(db)
     composeTestRule.setContent {
       calendarViewModel =
-          CalendarViewModel.createViewModel(dbs.admin1.id, userTable, availabilityTable)
+          CalendarViewModel.createViewModel(
+              dbs.admin1.id, userTable, availabilityTable, flightTable)
       val uiState = calendarViewModel.uiState.collectAsStateWithLifecycle()
       Text(text = uiState.value.user?.firstname ?: "Bob")
     }

--- a/app/src/androidTest/java/ch/epfl/skysync/viewmodel/FlightsViewModelTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/viewmodel/FlightsViewModelTest.kt
@@ -91,7 +91,7 @@ class FlightsViewModelTest {
     runTest {
       viewModelAdmin.refreshUserAndFlights().join()
       val currentFlights = viewModelAdmin.currentFlights.value
-      assertEquals(4, currentFlights?.size)
+      assertEquals(5, currentFlights?.size)
     }
   }
 
@@ -115,7 +115,7 @@ class FlightsViewModelTest {
     runTest {
       viewModelCrewPilot.refreshUserAndFlights().join()
       val currentFlights = viewModelCrewPilot.currentFlights.value
-      assertEquals(1, currentFlights?.size)
+      assertEquals(2, currentFlights?.size)
     }
   }
 
@@ -219,7 +219,7 @@ class FlightsViewModelTest {
               id = flightTable.add(flightWithoutCrew, onError = { assertNull(it) }))
 
       viewModelAdmin.refreshUserAndFlights().join()
-      assertEquals(6, viewModelAdmin.currentFlights.value?.size)
+      assertEquals(7, viewModelAdmin.currentFlights.value?.size)
     }
   }
 
@@ -251,7 +251,7 @@ class FlightsViewModelTest {
 
       viewModelAdmin.refreshUserAndFlights().join()
 
-      assertEquals(5, viewModelAdmin.currentFlights.value?.size)
+      assertEquals(6, viewModelAdmin.currentFlights.value?.size)
     }
   }
 
@@ -297,7 +297,7 @@ class FlightsViewModelTest {
               id = UNSET_ID)
       viewModelAdmin.refreshUserAndFlights().join()
       val initFlights = viewModelAdmin.currentFlights.value
-      assertEquals(4, initFlights?.size)
+      assertEquals(5, initFlights?.size)
 
       flight1 = flight1.copy(id = flightTable.add(flight1, onError = { assertNull(it) }))
 
@@ -306,7 +306,7 @@ class FlightsViewModelTest {
       viewModelAdmin.refreshUserAndFlights().join()
       val withFlightsAdded = viewModelAdmin.currentFlights.value
 
-      assertEquals(6, withFlightsAdded?.size)
+      assertEquals(7, withFlightsAdded?.size)
 
       viewModelAdmin.deleteFlight(flight1.id).join()
 
@@ -314,7 +314,7 @@ class FlightsViewModelTest {
 
       val withOneFlightDeleted = viewModelAdmin.currentFlights.value
 
-      assertEquals(5, withOneFlightDeleted?.size)
+      assertEquals(6, withOneFlightDeleted?.size)
       assertTrue(withOneFlightDeleted?.contains(flight2) ?: false)
       assertFalse(withOneFlightDeleted?.contains(flight1) ?: true)
     }
@@ -358,7 +358,7 @@ class FlightsViewModelTest {
 
       viewModelAdmin.refreshUserAndFlights().join()
 
-      assertEquals(5, viewModelAdmin.currentFlights.value?.size)
+      assertEquals(6, viewModelAdmin.currentFlights.value?.size)
       assertTrue(viewModelAdmin.currentFlights.value?.contains(modifiedFlight) ?: false)
     }
   }

--- a/app/src/main/java/ch/epfl/skysync/models/calendar/FlightGroupCalendar.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/calendar/FlightGroupCalendar.kt
@@ -44,4 +44,10 @@ class FlightGroupCalendar : CalendarModel<FlightGroup>() {
   fun getFlightGroupByDate(date: LocalDate, timeSlot: TimeSlot): FlightGroup? {
     return getByDate(date, timeSlot)
   }
+
+  fun addFlightList(flights: List<Flight>): FlightGroupCalendar {
+    if (flights.isEmpty()) return this
+    flights.forEach { flight -> addFlightByDate(flight.date, flight.timeSlot, flight) }
+    return this
+  }
 }

--- a/app/src/main/java/ch/epfl/skysync/navigation/PersonalCalendars.kt
+++ b/app/src/main/java/ch/epfl/skysync/navigation/PersonalCalendars.kt
@@ -17,13 +17,13 @@ fun NavGraphBuilder.personalCalendar(
     composable(Route.AVAILABILITY_CALENDAR) {
       val viewModel =
           CalendarViewModel.createViewModel(
-              uid!!, repository.userTable, repository.availabilityTable)
+              uid!!, repository.userTable, repository.availabilityTable, repository.flightTable)
       CalendarScreen(navController, Route.AVAILABILITY_CALENDAR, viewModel)
     }
     composable(Route.FLIGHT_CALENDAR) {
       val viewModel =
           CalendarViewModel.createViewModel(
-              uid!!, repository.userTable, repository.availabilityTable)
+              uid!!, repository.userTable, repository.availabilityTable, repository.flightTable)
       CalendarScreen(navController, Route.FLIGHT_CALENDAR, viewModel)
     }
   }

--- a/app/src/main/java/ch/epfl/skysync/screens/Calendar.kt
+++ b/app/src/main/java/ch/epfl/skysync/screens/Calendar.kt
@@ -69,7 +69,7 @@ fun CalendarScreen(
                 flightCalendar.getFirstFlightByDate(date, time)
               },
               onFlightClick = { selectedFlight ->
-                navController.navigate(Route.FLIGHT_DETAILS + "/${selectedFlight}")
+                // navController.navigate(Route.FLIGHT_DETAILS + "/${selectedFlight}")
               })
         }
       }

--- a/app/src/main/java/ch/epfl/skysync/viewmodel/CalendarViewModel.kt
+++ b/app/src/main/java/ch/epfl/skysync/viewmodel/CalendarViewModel.kt
@@ -100,8 +100,6 @@ class CalendarViewModel(
     loadingCounter.value += 1
     var newUser = userTable.get(uid, this::onError)!!
     newUser.availabilities.addCells(userTable.retrieveAvailabilities(uid, this::onError))
-    val flights = userTable.retrieveAssignedFlights(flightTable, uid, this::onError)
-    flights.forEach { newUser.assignedFlights.addFlightByDate(it.date, it.timeSlot, it) }
     loadingCounter.value -= 1
     user.value = newUser
     originalAvailabilityCalendar = newUser.availabilities.copy()

--- a/app/src/main/java/ch/epfl/skysync/viewmodel/CalendarViewModel.kt
+++ b/app/src/main/java/ch/epfl/skysync/viewmodel/CalendarViewModel.kt
@@ -65,23 +65,6 @@ class CalendarViewModel(
   private val loadingCounter = MutableStateFlow(0)
 
 
-    private val currentFlights:  StateFlow<List<Flight>> = user.map {
-        if (it != null) {
-            userTable.retrieveAssignedFlights(
-                flightTable,
-                it.id,
-                onError = { onError(it) })
-        }
-        else{
-            emptyList()
-        }
-    }.stateIn(
-        scope = viewModelScope,
-        started = WhileUiSubscribed,
-        initialValue = emptyList()
-    )
-
-
   private var originalAvailabilityCalendar = AvailabilityCalendar()
 
   val uiState: StateFlow<CalendarUiState> =

--- a/app/src/main/java/ch/epfl/skysync/viewmodel/CalendarViewModel.kt
+++ b/app/src/main/java/ch/epfl/skysync/viewmodel/CalendarViewModel.kt
@@ -11,7 +11,6 @@ import ch.epfl.skysync.database.tables.UserTable
 import ch.epfl.skysync.models.calendar.AvailabilityCalendar
 import ch.epfl.skysync.models.calendar.CalendarDifferenceType
 import ch.epfl.skysync.models.calendar.FlightGroupCalendar
-import ch.epfl.skysync.models.flight.Flight
 import ch.epfl.skysync.models.user.Admin
 import ch.epfl.skysync.models.user.User
 import ch.epfl.skysync.util.WhileUiSubscribed
@@ -19,7 +18,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -64,15 +62,13 @@ class CalendarViewModel(
   private val user: MutableStateFlow<User?> = MutableStateFlow(null)
   private val loadingCounter = MutableStateFlow(0)
 
-
   private var originalAvailabilityCalendar = AvailabilityCalendar()
 
   val uiState: StateFlow<CalendarUiState> =
       combine(user, loadingCounter) { user, loadingCounter ->
-          val flights = userTable.retrieveAssignedFlights(
-              flightTable,
-              user?.id?: "",
-              onError = { onError(it) })
+            val flights =
+                userTable.retrieveAssignedFlights(
+                    flightTable, user?.id ?: "", onError = { onError(it) })
 
             CalendarUiState(
                 user,
@@ -94,20 +90,7 @@ class CalendarViewModel(
    *
    * (Starts a new coroutine)
    */
-  fun refresh() = viewModelScope.launch {
-      refreshUser()
-  }
-
-
-//    suspend fun refreshFlights(){
-//        if (user.value != null) {
-//            _currentFlights.value
-//            userTable.retrieveAssignedFlights(
-//                flightTable,
-//                user.value!!.id,
-//                onError = { onError(it) })
-//        }
-//    }
+  fun refresh() = viewModelScope.launch { refreshUser() }
 
   /** Fetch the user from the database Update asynchronously the [CalendarUiState.user] reference */
   private suspend fun refreshUser() {


### PR DESCRIPTION
closes #267

# show personal flights in calendar

- the personal flight calendar is now connected to the DB
- the personal flights are added directly in the `CalendarViewModel` as opposed to be added to the previously dedicated location in the `User`. => Once the User management is clear (#270 ) we can decide to add synchronization of the personal flights in the UserTable.get() or remove the personal flights from the `User` class and keep the current implementation for the personal flights.
