### PR TITLE
User global view model

### DIFF
--- a/app/src/main/java/ch/epfl/skysync/MainActivity.kt
+++ b/app/src/main/java/ch/epfl/skysync/MainActivity.kt
@@ -7,65 +7,38 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.ActivityResultLauncher
 import androidx.compose.material3.Scaffold
-import androidx.compose.runtime.mutableStateOf
 import androidx.navigation.compose.rememberNavController
 import ch.epfl.skysync.components.GlobalSnackbarHost
-import ch.epfl.skysync.components.SnackbarManager
 import ch.epfl.skysync.database.FirestoreDatabase
 import ch.epfl.skysync.navigation.MainGraph
 import ch.epfl.skysync.ui.theme.SkySyncTheme
 import ch.epfl.skysync.viewmodel.TimerViewModel
+import ch.epfl.skysync.viewmodel.UserGlobalViewModel
 import com.firebase.ui.auth.FirebaseAuthUIActivityResultContract
 import com.firebase.ui.auth.data.model.FirebaseAuthUIAuthenticationResult
 import com.google.firebase.auth.FirebaseAuth
-import kotlinx.coroutines.runBlocking
 
 class MainActivity : ComponentActivity() {
   private lateinit var signInLauncher: ActivityResultLauncher<Intent>
-  private val userId = mutableStateOf<String?>(null)
+  private var userGlobalViewModel: UserGlobalViewModel? = null
   private val db: FirestoreDatabase = FirestoreDatabase()
   private val repository: Repository = Repository(db)
 
-  private fun onError(e: Exception) {
-    SnackbarManager.showMessage(e.message ?: "An unknown error occurred")
-  }
-
   private fun onSignInResult(result: FirebaseAuthUIAuthenticationResult) {
+    val vm = userGlobalViewModel ?: return
     if (result.resultCode == RESULT_OK) {
-      val incomingUser = FirebaseAuth.getInstance().currentUser!!
-      val email = incomingUser.email!!
-
-      runBlocking {
-        val userExists = repository.userTable.get(incomingUser.uid)
-        if (userExists != null) {
-          userId.value = incomingUser.uid
-
-          return@runBlocking
-        }
-
-        val tempUser = repository.tempUserTable.get(email)
-        if (tempUser != null) {
-          repository.userTable.set(
-              incomingUser.uid, tempUser.toUserSchema(incomingUser.uid).toModel())
-          repository.tempUserTable.delete(email)
-          userId.value = incomingUser.uid
-        } else {
-          userId.value = "default-user"
-        }
-      }
+      val user = FirebaseAuth.getInstance().currentUser!!
+      vm.loadUser(user.uid, user.email!!)
     }
-
-    val snackBarText =
-        if (userId.value == "default-user") "Authentication with default Admin user"
-        else "Authentication Successful"
-    SnackbarManager.showMessage(snackBarText)
   }
 
   @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
-    // Initialize the signInLauncher
+    // Initialize the signInLauncher here
+    // as it needs to be created in MainActivity before the application is started,
+    // that is before the setContent method is called
     signInLauncher =
         registerForActivityResult(FirebaseAuthUIActivityResultContract()) { res ->
           this.onSignInResult(res)
@@ -75,12 +48,13 @@ class MainActivity : ComponentActivity() {
       SkySyncTheme {
         val navController = rememberNavController()
         Scaffold(snackbarHost = { GlobalSnackbarHost() }) {
+          userGlobalViewModel = UserGlobalViewModel.createViewModel(repository)
           val timerVm = TimerViewModel.createViewModel() // is shared between all screens
           MainGraph(
               repository = repository,
               navHostController = navController,
               signInLauncher = signInLauncher,
-              uid = userId.value,
+              userGlobalViewModel = userGlobalViewModel!!,
               timer = timerVm,
           )
         }

--- a/app/src/main/java/ch/epfl/skysync/navigation/MainGraph.kt
+++ b/app/src/main/java/ch/epfl/skysync/navigation/MainGraph.kt
@@ -3,12 +3,15 @@ package ch.epfl.skysync.navigation
 import android.content.Intent
 import androidx.activity.result.ActivityResultLauncher
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import ch.epfl.skysync.Repository
 import ch.epfl.skysync.screens.LoginScreen
 import ch.epfl.skysync.viewmodel.TimerViewModel
+import ch.epfl.skysync.viewmodel.UserGlobalViewModel
 
 /** Graph of the whole navigation of the app */
 @Composable
@@ -16,13 +19,17 @@ fun MainGraph(
     repository: Repository,
     navHostController: NavHostController,
     signInLauncher: ActivityResultLauncher<Intent>,
-    uid: String?,
+    userGlobalViewModel: UserGlobalViewModel,
     timer: TimerViewModel
 ) {
+  val user by userGlobalViewModel.user.collectAsStateWithLifecycle()
   NavHost(
       navController = navHostController,
-      startDestination = if (uid == null) Route.LOGIN else Route.MAIN) {
-        homeGraph(repository, navHostController, uid, timer)
-        composable(Route.LOGIN) { LoginScreen(signInLauncher = signInLauncher) }
+      startDestination = if (user == null) Route.LOGIN else Route.MAIN) {
+        // only pass the uid for the moment as passing a user object
+        // poses the question of how and when to refresh it
+        // and we would need to change the structure of all view models and tests
+        homeGraph(repository, navHostController, user?.id, timer)
+        composable(Route.LOGIN) { LoginScreen(userGlobalViewModel, signInLauncher) }
       }
 }

--- a/app/src/main/java/ch/epfl/skysync/screens/LoginScreen.kt
+++ b/app/src/main/java/ch/epfl/skysync/screens/LoginScreen.kt
@@ -16,15 +16,23 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import ch.epfl.skysync.components.LoadingComponent
+import ch.epfl.skysync.viewmodel.UserGlobalViewModel
 import com.firebase.ui.auth.AuthUI
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun LoginScreen(signInLauncher: ActivityResultLauncher<Intent>) {
+fun LoginScreen(
+    userGlobalViewModel: UserGlobalViewModel,
+    signInLauncher: ActivityResultLauncher<Intent>
+) {
+  val isLoading by userGlobalViewModel.isLoading.collectAsStateWithLifecycle()
 
   val providers =
       listOf(
@@ -34,19 +42,23 @@ fun LoginScreen(signInLauncher: ActivityResultLauncher<Intent>) {
   val signInIntent =
       AuthUI.getInstance().createSignInIntentBuilder().setAvailableProviders(providers).build()
 
-  Surface(modifier = Modifier.fillMaxSize()) {
-    Column(
-        modifier = Modifier.fillMaxSize().padding(16.dp).testTag("LoginScreen"),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center) {
-          Button(
-              modifier = Modifier.testTag("LoginButton"),
-              onClick = { signInLauncher.launch(signInIntent) }) {
-                Icon(imageVector = Icons.Default.Check, contentDescription = null)
-                Spacer(modifier = Modifier.width(8.dp))
-                Text("Sign in with Google")
-              }
-          Text(text = "You need to log in")
-        }
+  if (isLoading) {
+    LoadingComponent(isLoading = true, onRefresh = {}) {}
+  } else {
+    Surface(modifier = Modifier.fillMaxSize()) {
+      Column(
+          modifier = Modifier.fillMaxSize().padding(16.dp).testTag("LoginScreen"),
+          horizontalAlignment = Alignment.CenterHorizontally,
+          verticalArrangement = Arrangement.Center) {
+            Button(
+                modifier = Modifier.testTag("LoginButton"),
+                onClick = { signInLauncher.launch(signInIntent) }) {
+                  Icon(imageVector = Icons.Default.Check, contentDescription = null)
+                  Spacer(modifier = Modifier.width(8.dp))
+                  Text("Sign in with Google")
+                }
+            Text(text = "You need to log in")
+          }
+    }
   }
 }

--- a/app/src/main/java/ch/epfl/skysync/viewmodel/UserGlobalViewModel.kt
+++ b/app/src/main/java/ch/epfl/skysync/viewmodel/UserGlobalViewModel.kt
@@ -1,0 +1,88 @@
+package ch.epfl.skysync.viewmodel
+
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.compose.viewModel
+import ch.epfl.skysync.Repository
+import ch.epfl.skysync.components.SnackbarManager
+import ch.epfl.skysync.models.user.User
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class UserGlobalViewModel(
+    repository: Repository,
+) : ViewModel() {
+  companion object {
+    @Composable
+    fun createViewModel(repository: Repository): UserGlobalViewModel {
+      return viewModel<UserGlobalViewModel>(
+          factory =
+              object : ViewModelProvider.Factory {
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                  return UserGlobalViewModel(repository) as T
+                }
+              })
+    }
+  }
+
+  private val userTable = repository.userTable
+  private val tempUserTable = repository.tempUserTable
+
+  private val _user: MutableStateFlow<User?> = MutableStateFlow(null)
+  private val _isLoading = MutableStateFlow(false)
+
+  val user = _user.asStateFlow()
+  val isLoading = _isLoading.asStateFlow()
+
+  /**
+   * Loads a user one of the following ways:
+   * - If the user already exists, fetch it from user table
+   * - If the user has just been created by an admin and it is the first time the user connects,
+   *   fetch it from the temp user table
+   * - If the user doesn't exists, connect with a default admin account for testing purposes
+   *
+   *     @param uid The Firebase authentication uid of the user
+   *     @param email The email address of the user
+   */
+  fun loadUser(uid: String, email: String) =
+      viewModelScope.launch {
+        _isLoading.value = true
+
+        // Case 1: User exists, fetch it from user table
+        val user = userTable.get(uid, onError = { onError(it) })
+        if (user != null) {
+          _user.value = user
+          _isLoading.value = false
+          return@launch
+        }
+
+        // Case 2: First connection since user creation, it is in the temp user table
+        val tempUser = tempUserTable.get(email, onError = { onError(it) })
+        if (tempUser != null) {
+          val newUser = tempUser.toUserSchema(uid).toModel()
+          userTable.set(uid, newUser, onError = { onError(it) })
+          tempUserTable.delete(email)
+          _user.value = newUser
+          _isLoading.value = false
+          return@launch
+        }
+
+        // Case 3: User doesn't exists, connect with default admin account
+        val defaultUser = userTable.get("default-user", onError = { onError(it) })
+        if (defaultUser != null) {
+          _user.value = defaultUser
+          SnackbarManager.showMessage("Authentication with default Admin user")
+        } else {
+          onError(Exception("Default user not found."))
+        }
+        _isLoading.value = false
+      }
+
+  /** Callback executed when an error occurs on database-related operations */
+  private fun onError(e: Exception) {
+    SnackbarManager.showMessage(e.message ?: "An unknown error occurred")
+  }
+}


### PR DESCRIPTION
* Create `UserGlobalViewModel` that fetch the user (and handle temp user / default user) after the sign in
* Update `MainGraph` to use this view model
* Did not update `homeGraph` and further down to take a `User` object instead of `uid` is this would require to refactore the whole navigation graph, the view models and the tests. Also, with the #289 PR open in parallel this would create a lot of complications

Close #263