### PR TITLE
Stat screen admin placeholder

### DIFF
--- a/app/src/androidTest/java/ch/epfl/skysync/screens/AdminStatsScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/screens/AdminStatsScreenTest.kt
@@ -1,0 +1,29 @@
+package ch.epfl.skysync.screens
+
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.navigation.testing.TestNavHostController
+import ch.epfl.skysync.screens.admin.AdminStatsScreen
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class AdminStatsScreenTest {
+  @get:Rule val composeTestRule = createComposeRule()
+  lateinit var navController: TestNavHostController
+
+  @Before
+  fun setUp() {
+    composeTestRule.setContent {
+      navController = TestNavHostController(LocalContext.current)
+      AdminStatsScreen(navController)
+    }
+  }
+
+  @Test
+  fun isTextDisplayed() {
+    composeTestRule.onNodeWithText("Feature not available").assertIsDisplayed()
+  }
+}

--- a/app/src/main/java/ch/epfl/skysync/navigation/AdminGraph.kt
+++ b/app/src/main/java/ch/epfl/skysync/navigation/AdminGraph.kt
@@ -18,6 +18,7 @@ import ch.epfl.skysync.screens.admin.AddUserScreen
 import ch.epfl.skysync.screens.admin.AdminChatScreen
 import ch.epfl.skysync.screens.admin.AdminFlightDetailScreen
 import ch.epfl.skysync.screens.admin.AdminHomeScreen
+import ch.epfl.skysync.screens.admin.AdminStatsScreen
 import ch.epfl.skysync.screens.admin.AdminTextScreen
 import ch.epfl.skysync.screens.admin.ConfirmationScreen
 import ch.epfl.skysync.screens.admin.ModifyFlightScreen
@@ -44,9 +45,7 @@ fun NavGraphBuilder.adminGraph(
       val flightsViewModel = FlightsViewModel.createViewModel(repository, uid)
       AddFlightScreen(navController, flightsViewModel)
     }
-    composable(Route.STATS) {
-      // TODO
-    }
+    composable(Route.STATS) { AdminStatsScreen(navController) }
     composable(Route.ADD_USER) { AddUserScreen(navController) }
     composable(
         Route.CONFIRM_FLIGHT + "/{Flight ID}",

--- a/app/src/main/java/ch/epfl/skysync/screens/admin/AdminStats.kt
+++ b/app/src/main/java/ch/epfl/skysync/screens/admin/AdminStats.kt
@@ -1,0 +1,30 @@
+package ch.epfl.skysync.screens.admin
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
+import ch.epfl.skysync.navigation.AdminBottomBar
+
+@Composable
+fun AdminStatsScreen(
+    navController: NavHostController
+    // , viewModel: StatsViewModel){
+) {
+  Scaffold(modifier = Modifier.fillMaxSize(), bottomBar = { AdminBottomBar(navController) }) {
+      padding ->
+    Column(
+        modifier = Modifier.fillMaxSize().padding(padding),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally) {
+          Text(text = "Feature not available", fontSize = 24.sp)
+        }
+  }
+}


### PR DESCRIPTION
closes #319
just a text that shows "Feature not available", when clicking on AdminStats from the bottom-bar as an admin.