### PR TITLE
Ongoing flight backend

### DIFF
--- a/app/src/androidTest/java/ch/epfl/skysync/components/TimerTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/components/TimerTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import ch.epfl.skysync.viewmodel.InFlightViewModel
 import org.junit.Assert.assertFalse
 import org.junit.Rule
 import org.junit.Test
@@ -17,7 +18,13 @@ class TimerTest {
   fun timerIsDisplayedWithWithButton() {
     composeTestRule.setContent {
       Timer(
-          modifier = Modifier, currentTimer = "0:0:0", isRunning = false, onStart = {}, onStop = {})
+          modifier = Modifier,
+          currentTimer = "0:0:0",
+          flightStage = InFlightViewModel.FlightStage.IDLE,
+          isPilot = true,
+          onStart = {},
+          onStop = {},
+          onClear = {})
     }
     composeTestRule.onNodeWithTag("Timer").assertExists()
     composeTestRule.onNodeWithTag("Timer Value").assertIsDisplayed()
@@ -33,9 +40,12 @@ class TimerTest {
       Timer(
           modifier = Modifier,
           currentTimer = "0:0:0",
-          isRunning = false,
+          flightStage = InFlightViewModel.FlightStage.IDLE,
+          isPilot = true,
           onStart = { controlVariableOnStart = true },
-          onStop = { controlVariableOnStop = true })
+          onStop = { controlVariableOnStop = true },
+          onClear = {},
+      )
     }
     composeTestRule.onNodeWithTag("Start Button").performClick()
     assert(controlVariableOnStart)
@@ -50,9 +60,12 @@ class TimerTest {
       Timer(
           modifier = Modifier,
           currentTimer = "0:0:0",
-          isRunning = true,
+          flightStage = InFlightViewModel.FlightStage.ONGOING,
+          isPilot = true,
           onStart = { controlVariableOnStart = true },
-          onStop = { controlVariableOnStop = true })
+          onStop = { controlVariableOnStop = true },
+          onClear = {},
+      )
     }
     composeTestRule.onNodeWithTag("Stop Button").performClick()
     assert(controlVariableOnStop)

--- a/app/src/androidTest/java/ch/epfl/skysync/components/calendar/AvailabiltyCalendarTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/components/calendar/AvailabiltyCalendarTest.kt
@@ -21,6 +21,7 @@ import ch.epfl.skysync.database.FirestoreDatabase
 import ch.epfl.skysync.models.calendar.TimeSlot
 import ch.epfl.skysync.navigation.Route
 import ch.epfl.skysync.navigation.homeGraph
+import ch.epfl.skysync.viewmodel.InFlightViewModel
 import java.time.LocalDate
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
@@ -43,8 +44,9 @@ class AvailabiltyCalendarTest {
     composeTestRule.setContent {
       navController = TestNavHostController(LocalContext.current)
       navController.navigatorProvider.addNavigator(ComposeNavigator())
+      val inFlightViewModel = InFlightViewModel.createViewModel(repository)
       NavHost(navController = navController, startDestination = Route.MAIN) {
-        homeGraph(repository, navController, dbs.crew1.id)
+        homeGraph(repository, navController, dbs.crew1.id, inFlightViewModel)
       }
     }
     composeTestRule.waitUntil {

--- a/app/src/androidTest/java/ch/epfl/skysync/components/calendar/CalendarTopBarTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/components/calendar/CalendarTopBarTest.kt
@@ -14,6 +14,7 @@ import ch.epfl.skysync.database.DatabaseSetup
 import ch.epfl.skysync.database.FirestoreDatabase
 import ch.epfl.skysync.navigation.Route
 import ch.epfl.skysync.navigation.homeGraph
+import ch.epfl.skysync.viewmodel.InFlightViewModel
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
@@ -39,8 +40,9 @@ class CalendarTopBarTest {
     composeTestRule.setContent {
       navController = TestNavHostController(LocalContext.current)
       navController.navigatorProvider.addNavigator(ComposeNavigator())
+      val inFlightViewModel = InFlightViewModel.createViewModel(repository)
       NavHost(navController = navController, startDestination = Route.MAIN) {
-        homeGraph(repository, navController, dbs.crew1.id)
+        homeGraph(repository, navController, dbs.crew1.id, inFlightViewModel)
       }
     }
     composeTestRule.waitUntil {

--- a/app/src/androidTest/java/ch/epfl/skysync/components/calendar/FlightCalendarTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/components/calendar/FlightCalendarTest.kt
@@ -19,6 +19,7 @@ import ch.epfl.skysync.database.FirestoreDatabase
 import ch.epfl.skysync.models.calendar.TimeSlot
 import ch.epfl.skysync.navigation.Route
 import ch.epfl.skysync.navigation.homeGraph
+import ch.epfl.skysync.viewmodel.InFlightViewModel
 import java.time.LocalDate
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
@@ -40,8 +41,9 @@ class FlightCalendarTest {
     composeTestRule.setContent {
       navController = TestNavHostController(LocalContext.current)
       navController.navigatorProvider.addNavigator(ComposeNavigator())
+      val inFlightViewModel = InFlightViewModel.createViewModel(repository)
       NavHost(navController = navController, startDestination = Route.MAIN) {
-        homeGraph(repository, navController, dbs.crew1.id)
+        homeGraph(repository, navController, dbs.crew1.id, inFlightViewModel)
       }
     }
     composeTestRule.waitUntil {

--- a/app/src/androidTest/java/ch/epfl/skysync/database/DatabaseSetup.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/database/DatabaseSetup.kt
@@ -19,6 +19,7 @@ import ch.epfl.skysync.models.calendar.AvailabilityCalendar
 import ch.epfl.skysync.models.calendar.AvailabilityStatus
 import ch.epfl.skysync.models.calendar.FlightGroupCalendar
 import ch.epfl.skysync.models.calendar.TimeSlot
+import ch.epfl.skysync.models.calendar.getTimeSlot
 import ch.epfl.skysync.models.flight.Balloon
 import ch.epfl.skysync.models.flight.BalloonQualification
 import ch.epfl.skysync.models.flight.Basket
@@ -216,7 +217,7 @@ class DatabaseSetup {
           balloon = balloon1,
           basket = basket1,
           date = date2,
-          timeSlot = TimeSlot.PM,
+          timeSlot = getTimeSlot(LocalTime.now()),
           vehicles = listOf(vehicle2),
           remarks = listOf("remark 1", "remark 2"),
           color = FlightColor.BLUE,

--- a/app/src/androidTest/java/ch/epfl/skysync/database/DatabaseSetup.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/database/DatabaseSetup.kt
@@ -128,6 +128,8 @@ class DatabaseSetup {
 
   // this the date of flight4, it needs to be today for the InFlightViewModel tests
   var date2 = LocalDate.now()
+  var date2TimeSlot = getTimeSlot(LocalTime.now())
+
   var dateNoFlight = LocalDate.of(2024, 8, 16)
 
   var availability1Crew1 =
@@ -135,21 +137,21 @@ class DatabaseSetup {
   var availability2Crew1 =
       Availability(status = AvailabilityStatus.OK, timeSlot = TimeSlot.PM, date = date1)
   var availability3Crew1 =
-      Availability(status = AvailabilityStatus.OK, timeSlot = TimeSlot.PM, date = date2)
+      Availability(status = AvailabilityStatus.OK, timeSlot = date2TimeSlot, date = date2)
 
   var availability1Crew2 =
       Availability(status = AvailabilityStatus.OK, timeSlot = TimeSlot.AM, date = date1)
   var availability2Crew2 =
       Availability(status = AvailabilityStatus.OK, timeSlot = TimeSlot.PM, date = date1)
   var availability3Crew2 =
-      Availability(status = AvailabilityStatus.OK, timeSlot = TimeSlot.PM, date = date2)
+      Availability(status = AvailabilityStatus.OK, timeSlot = date2TimeSlot, date = date2)
 
   var availability1Pilot1 =
       Availability(status = AvailabilityStatus.OK, timeSlot = TimeSlot.AM, date = date1)
   var availability2Pilot1 =
       Availability(status = AvailabilityStatus.OK, timeSlot = TimeSlot.PM, date = date1)
   var availability3Pilot1 =
-      Availability(status = AvailabilityStatus.OK, timeSlot = TimeSlot.PM, date = date2)
+      Availability(status = AvailabilityStatus.OK, timeSlot = date2TimeSlot, date = date2)
 
   var availability1Pilot2 =
       Availability(status = AvailabilityStatus.OK, timeSlot = TimeSlot.AM, date = date1)
@@ -227,7 +229,7 @@ class DatabaseSetup {
           balloon = balloon1,
           basket = basket1,
           date = date2,
-          timeSlot = getTimeSlot(LocalTime.now()),
+          timeSlot = date2TimeSlot,
           vehicles = listOf(vehicle2),
           remarks = listOf("remark 1", "remark 2"),
           color = FlightColor.BLUE,

--- a/app/src/androidTest/java/ch/epfl/skysync/database/DatabaseSetup.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/database/DatabaseSetup.kt
@@ -113,8 +113,10 @@ class DatabaseSetup {
           assignedFlights = FlightGroupCalendar(),
           qualification = BalloonQualification.SMALL)
 
-  var date1 = LocalDate.of(2024, 8, 12)
-  var date2 = LocalDate.of(2024, 8, 14)
+  var date1 = LocalDate.of(2024, 8, 14)
+
+  // this the date of flight4, it needs to be today for the InFlightViewModel tests
+  var date2 = LocalDate.now()
   var dateNoFlight = LocalDate.of(2024, 8, 16)
 
   var availability1Crew1 =

--- a/app/src/androidTest/java/ch/epfl/skysync/flightdetail/IntegrateFlightDetailTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/flightdetail/IntegrateFlightDetailTest.kt
@@ -14,6 +14,7 @@ import ch.epfl.skysync.database.DatabaseSetup
 import ch.epfl.skysync.database.FirestoreDatabase
 import ch.epfl.skysync.navigation.Route
 import ch.epfl.skysync.navigation.homeGraph
+import ch.epfl.skysync.viewmodel.InFlightViewModel
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -34,8 +35,9 @@ class IntegrateFlightDetailTest {
     composeTestRule.setContent {
       navController = TestNavHostController(LocalContext.current)
       navController.navigatorProvider.addNavigator(ComposeNavigator())
+      val inFlightViewModel = InFlightViewModel.createViewModel(repository)
       NavHost(navController = navController, startDestination = Route.MAIN) {
-        homeGraph(repository, navController, dbs.crew1.id)
+        homeGraph(repository, navController, dbs.crew1.id, inFlightViewModel)
       }
     }
     composeTestRule.waitUntil {

--- a/app/src/androidTest/java/ch/epfl/skysync/navigation/AdminBottomBarTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/navigation/AdminBottomBarTest.kt
@@ -12,6 +12,7 @@ import androidx.navigation.testing.TestNavHostController
 import ch.epfl.skysync.Repository
 import ch.epfl.skysync.database.DatabaseSetup
 import ch.epfl.skysync.database.FirestoreDatabase
+import ch.epfl.skysync.viewmodel.InFlightViewModel
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
@@ -32,8 +33,9 @@ class AdminBottomBarTest {
       val repository = Repository(db)
       navController = TestNavHostController(LocalContext.current)
       navController.navigatorProvider.addNavigator(ComposeNavigator())
+      val inFlightViewModel = InFlightViewModel.createViewModel(repository)
       NavHost(navController = navController, startDestination = Route.MAIN) {
-        homeGraph(repository, navController, dbs.admin1.id)
+        homeGraph(repository, navController, dbs.admin1.id, inFlightViewModel)
       }
     }
     composeTestRule.waitUntil {

--- a/app/src/androidTest/java/ch/epfl/skysync/navigation/HomeNavigationTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/navigation/HomeNavigationTest.kt
@@ -11,6 +11,7 @@ import androidx.navigation.testing.TestNavHostController
 import ch.epfl.skysync.Repository
 import ch.epfl.skysync.database.DatabaseSetup
 import ch.epfl.skysync.database.FirestoreDatabase
+import ch.epfl.skysync.viewmodel.InFlightViewModel
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
@@ -32,8 +33,9 @@ class HomeNavigationTest {
       val repository = Repository(db)
       navController = TestNavHostController(LocalContext.current)
       navController.navigatorProvider.addNavigator(ComposeNavigator())
+      val inFlightViewModel = InFlightViewModel.createViewModel(repository)
       NavHost(navController = navController, startDestination = Route.MAIN) {
-        homeGraph(repository, navController, dbs.crew1.id)
+        homeGraph(repository, navController, dbs.crew1.id, inFlightViewModel)
       }
     }
     composeTestRule.waitUntil {

--- a/app/src/androidTest/java/ch/epfl/skysync/screens/flight/FlightScreenNoPermissionTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/screens/flight/FlightScreenNoPermissionTest.kt
@@ -11,7 +11,7 @@ import ch.epfl.skysync.Repository
 import ch.epfl.skysync.database.DatabaseSetup
 import ch.epfl.skysync.database.FirestoreDatabase
 import ch.epfl.skysync.screens.crewpilot.FlightScreen
-import ch.epfl.skysync.viewmodel.LocationViewModel
+import ch.epfl.skysync.viewmodel.InFlightViewModel
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -25,10 +25,10 @@ class FlightScreenNoPermissionTest {
     val db = FirestoreDatabase(useEmulator = true)
     val repository = Repository(db)
     composeTestRule.setContent {
-      val locationViewModel = LocationViewModel.createViewModel(dbs.pilot1.id, repository)
+      val inFlightViewModel = InFlightViewModel.createViewModel(dbs.pilot1.id, repository)
       val navController = rememberNavController()
       val uid = dbs.pilot1.id
-      FlightScreen(navController = navController, inFlightViewModel = locationViewModel, uid)
+      FlightScreen(navController = navController, inFlightViewModel = inFlightViewModel, uid)
     }
   }
 

--- a/app/src/androidTest/java/ch/epfl/skysync/screens/flight/FlightScreenNoPermissionTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/screens/flight/FlightScreenNoPermissionTest.kt
@@ -25,7 +25,7 @@ class FlightScreenNoPermissionTest {
     val db = FirestoreDatabase(useEmulator = true)
     val repository = Repository(db)
     composeTestRule.setContent {
-      val inFlightViewModel = InFlightViewModel.createViewModel(dbs.pilot1.id, repository)
+      val inFlightViewModel = InFlightViewModel.createViewModel(repository)
       val navController = rememberNavController()
       val uid = dbs.pilot1.id
       FlightScreen(navController = navController, inFlightViewModel = inFlightViewModel, uid)

--- a/app/src/androidTest/java/ch/epfl/skysync/screens/flight/FlightScreenPermissionTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/screens/flight/FlightScreenPermissionTest.kt
@@ -14,7 +14,7 @@ import ch.epfl.skysync.Repository
 import ch.epfl.skysync.database.DatabaseSetup
 import ch.epfl.skysync.database.FirestoreDatabase
 import ch.epfl.skysync.screens.crewpilot.FlightScreen
-import ch.epfl.skysync.viewmodel.LocationViewModel
+import ch.epfl.skysync.viewmodel.InFlightViewModel
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
@@ -23,7 +23,7 @@ import org.junit.Test
 class FlightScreenPermissionTest {
   @get:Rule val composeTestRule = createComposeRule()
 
-  lateinit var locationViewModel: LocationViewModel
+  lateinit var inFlightViewModel: InFlightViewModel
   lateinit var dbs: DatabaseSetup
 
   @get:Rule
@@ -39,12 +39,12 @@ class FlightScreenPermissionTest {
     val repository = Repository(db)
     val uid = dbs.pilot1.id
     composeTestRule.setContent {
-      locationViewModel = LocationViewModel.createViewModel(uid, repository)
+      inFlightViewModel = InFlightViewModel.createViewModel(uid, repository)
       val navController = rememberNavController()
-      FlightScreen(navController, inFlightViewModel = locationViewModel, uid)
+      FlightScreen(navController, inFlightViewModel = inFlightViewModel, uid)
     }
-    locationViewModel.refreshPersonalFlights().join()
-    locationViewModel.setFlightId(dbs.flight1.id)
+    inFlightViewModel.refreshFlights().join()
+    inFlightViewModel.setFlightId(dbs.flight1.id)
   }
 
   @Test

--- a/app/src/androidTest/java/ch/epfl/skysync/screens/flight/FlightScreenPermissionTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/screens/flight/FlightScreenPermissionTest.kt
@@ -39,12 +39,12 @@ class FlightScreenPermissionTest {
     val repository = Repository(db)
     val uid = dbs.pilot1.id
     composeTestRule.setContent {
-      inFlightViewModel = InFlightViewModel.createViewModel(uid, repository)
+      inFlightViewModel = InFlightViewModel.createViewModel(repository)
       val navController = rememberNavController()
       FlightScreen(navController, inFlightViewModel = inFlightViewModel, uid)
     }
-    inFlightViewModel.refreshFlights().join()
-    inFlightViewModel.setFlightId(dbs.flight1.id)
+    inFlightViewModel.init(dbs.pilot1.id).join()
+    inFlightViewModel.setCurrentFlight(uid)
   }
 
   @Test

--- a/app/src/androidTest/java/ch/epfl/skysync/screens/flight/FlightScreenPermissionTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/screens/flight/FlightScreenPermissionTest.kt
@@ -44,7 +44,7 @@ class FlightScreenPermissionTest {
       FlightScreen(navController, inFlightViewModel = inFlightViewModel, uid)
     }
     inFlightViewModel.init(dbs.pilot1.id).join()
-    inFlightViewModel.setCurrentFlight(uid)
+    inFlightViewModel.setCurrentFlight(dbs.flight4.id)
   }
 
   @Test

--- a/app/src/androidTest/java/ch/epfl/skysync/test_end_to_end/E2EAddFlights.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/test_end_to_end/E2EAddFlights.kt
@@ -18,6 +18,7 @@ import ch.epfl.skysync.database.DatabaseSetup
 import ch.epfl.skysync.database.FirestoreDatabase
 import ch.epfl.skysync.navigation.Route
 import ch.epfl.skysync.navigation.homeGraph
+import ch.epfl.skysync.viewmodel.InFlightViewModel
 import junit.framework.TestCase.assertNull
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
@@ -39,8 +40,9 @@ class E2EAddFlights {
     composeTestRule.setContent {
       navController = TestNavHostController(LocalContext.current)
       navController.navigatorProvider.addNavigator(ComposeNavigator())
+      val inFlightViewModel = InFlightViewModel.createViewModel(repository)
       NavHost(navController = navController, startDestination = Route.MAIN) {
-        homeGraph(repository, navController, dbs.admin1.id)
+        homeGraph(repository, navController, dbs.admin1.id, inFlightViewModel)
       }
     }
     composeTestRule.waitUntil {

--- a/app/src/androidTest/java/ch/epfl/skysync/test_end_to_end/E2ECrewFlightDetail.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/test_end_to_end/E2ECrewFlightDetail.kt
@@ -22,6 +22,7 @@ import ch.epfl.skysync.models.flight.Flight
 import ch.epfl.skysync.models.flight.PlannedFlight
 import ch.epfl.skysync.navigation.Route
 import ch.epfl.skysync.navigation.homeGraph
+import ch.epfl.skysync.viewmodel.InFlightViewModel
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Assert.assertEquals
@@ -49,8 +50,9 @@ class E2ECrewFlightDetail {
     composeTestRule.setContent {
       navController = TestNavHostController(LocalContext.current)
       navController.navigatorProvider.addNavigator(ComposeNavigator())
+      val inFlightViewModel = InFlightViewModel.createViewModel(repository)
       NavHost(navController = navController, startDestination = Route.MAIN) {
-        homeGraph(repository, navController, dbs.crew1.id)
+        homeGraph(repository, navController, dbs.crew1.id, inFlightViewModel)
       }
     }
     composeTestRule.waitUntil {

--- a/app/src/androidTest/java/ch/epfl/skysync/test_end_to_end/E2EModifyAndDeleteFlights.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/test_end_to_end/E2EModifyAndDeleteFlights.kt
@@ -19,6 +19,7 @@ import ch.epfl.skysync.database.DatabaseSetup
 import ch.epfl.skysync.database.FirestoreDatabase
 import ch.epfl.skysync.navigation.Route
 import ch.epfl.skysync.navigation.homeGraph
+import ch.epfl.skysync.viewmodel.InFlightViewModel
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
@@ -40,8 +41,9 @@ class E2EModifyAndDeleteFlights {
     composeTestRule.setContent {
       navController = TestNavHostController(LocalContext.current)
       navController.navigatorProvider.addNavigator(ComposeNavigator())
+      val inFlightViewModel = InFlightViewModel.createViewModel(repository)
       NavHost(navController = navController, startDestination = Route.MAIN) {
-        homeGraph(repository, navController, dbs.admin1.id)
+        homeGraph(repository, navController, dbs.admin1.id, inFlightViewModel)
       }
     }
     composeTestRule.waitUntil(2500) {

--- a/app/src/androidTest/java/ch/epfl/skysync/test_end_to_end/E2EPilotDuringFlight.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/test_end_to_end/E2EPilotDuringFlight.kt
@@ -70,12 +70,13 @@ class E2EPilotDuringFlight {
       // Refreshes chat and user data asynchronously
       chatViewModel.refresh().join()
       chatViewModel.refreshUser().join()
-      inFlightViewModel.refreshFlights().join()
+      inFlightViewModel.init(dbs.pilot1.id).join()
 
       // Clicks on the "Flight" button to navigate to the flight screen
       composeTestRule.onNodeWithText("Flight").performClick()
       var route = navController.currentBackStackEntry?.destination?.route
       Assert.assertEquals(Route.FLIGHT, route)
+      println("FLIGHTS ${listOf(dbs.flight1.id, dbs.flight2.id, dbs.flight3.id, dbs.flight4.id)}")
       var usedFlightId = ""
       for (f in listOf(dbs.flight1, dbs.flight2, dbs.flight3, dbs.flight4)) {
         if (composeTestRule.onNodeWithTag("flightCard${f.id}").isDisplayed()) {

--- a/app/src/androidTest/java/ch/epfl/skysync/test_end_to_end/E2EPilotDuringFlight.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/test_end_to_end/E2EPilotDuringFlight.kt
@@ -21,7 +21,7 @@ import ch.epfl.skysync.database.FirestoreDatabase
 import ch.epfl.skysync.navigation.Route
 import ch.epfl.skysync.navigation.homeGraph
 import ch.epfl.skysync.viewmodel.ChatViewModel
-import ch.epfl.skysync.viewmodel.LocationViewModel
+import ch.epfl.skysync.viewmodel.InFlightViewModel
 import ch.epfl.skysync.viewmodel.MessageListenerSharedViewModel
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
@@ -41,7 +41,7 @@ class E2EPilotDuringFlight {
   private val repository = Repository(db)
   private lateinit var messageListenerSharedViewModel: MessageListenerSharedViewModel
   private lateinit var chatViewModel: ChatViewModel
-  private lateinit var inFlightViewModel: LocationViewModel
+  private lateinit var inFlightViewModel: InFlightViewModel
 
   @Before
   fun setUpNavHost() = runTest {
@@ -53,7 +53,7 @@ class E2EPilotDuringFlight {
           ChatViewModel.createViewModel(dbs.pilot1.id, messageListenerSharedViewModel, repository)
       navController = TestNavHostController(LocalContext.current)
       navController.navigatorProvider.addNavigator(ComposeNavigator())
-      inFlightViewModel = LocationViewModel.createViewModel(dbs.pilot1.id, repository)
+      inFlightViewModel = InFlightViewModel.createViewModel(dbs.pilot1.id, repository)
       NavHost(navController = navController, startDestination = Route.MAIN) {
         homeGraph(repository, navController, dbs.pilot1.id, inFlightViewModel)
       }
@@ -70,7 +70,7 @@ class E2EPilotDuringFlight {
       // Refreshes chat and user data asynchronously
       chatViewModel.refresh().join()
       chatViewModel.refreshUser().join()
-      inFlightViewModel.refreshPersonalFlights().join()
+      inFlightViewModel.refreshFlights().join()
 
       // Clicks on the "Flight" button to navigate to the flight screen
       composeTestRule.onNodeWithText("Flight").performClick()

--- a/app/src/androidTest/java/ch/epfl/skysync/test_end_to_end/E2EPilotDuringFlight.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/test_end_to_end/E2EPilotDuringFlight.kt
@@ -53,7 +53,7 @@ class E2EPilotDuringFlight {
           ChatViewModel.createViewModel(dbs.pilot1.id, messageListenerSharedViewModel, repository)
       navController = TestNavHostController(LocalContext.current)
       navController.navigatorProvider.addNavigator(ComposeNavigator())
-      inFlightViewModel = InFlightViewModel.createViewModel(dbs.pilot1.id, repository)
+      inFlightViewModel = InFlightViewModel.createViewModel(repository)
       NavHost(navController = navController, startDestination = Route.MAIN) {
         homeGraph(repository, navController, dbs.pilot1.id, inFlightViewModel)
       }

--- a/app/src/androidTest/java/ch/epfl/skysync/viewmodel/InFlightViewModelTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/viewmodel/InFlightViewModelTest.kt
@@ -22,7 +22,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class LocationViewModelTest {
+class InFlightViewModelTest {
 
   @get:Rule val composeTestRule = createComposeRule()
   private val db = FirestoreDatabase(useEmulator = true)
@@ -31,87 +31,87 @@ class LocationViewModelTest {
   private val flightTable = repository.flightTable
   private val flightTraceTable = repository.flightTraceTable
   private val locationTable = repository.locationTable
-  private lateinit var locationViewModel: LocationViewModel
+  private lateinit var inFlightViewModel: InFlightViewModel
 
   @Before
   fun testSetUp() = runTest {
     dbs.clearDatabase(db)
     dbs.fillDatabase(db)
     composeTestRule.setContent {
-      locationViewModel = LocationViewModel.createViewModel(dbs.pilot1.id, repository = repository)
-      val countString by locationViewModel.counter.collectAsStateWithLifecycle()
+      inFlightViewModel = InFlightViewModel.createViewModel(dbs.pilot1.id, repository = repository)
+      val countString by inFlightViewModel.counter.collectAsStateWithLifecycle()
       Text(countString)
     }
-    locationViewModel.refreshPersonalFlights().join()
+    inFlightViewModel.refreshFlights().join()
   }
 
   @Test
   fun timerIsZeroBeforeStart() = runTest {
-    val countString = locationViewModel.counter.value
+    val countString = inFlightViewModel.counter.value
     assertTrue(countString == "00:00:00")
   }
 
   @Test
   fun testStartFunction() {
-    locationViewModel.setFlightId(dbs.flight1.id)
-    locationViewModel.startFlight()
+    inFlightViewModel.setFlightId(dbs.flight1.id)
+    inFlightViewModel.startFlight()
 
     composeTestRule.waitUntil(timeoutMillis = 1500) {
-      val countString = locationViewModel.counter.value
+      val countString = inFlightViewModel.counter.value
       countString == "00:00:01"
     }
-    val isRunning = locationViewModel.inFlight.value
+    val isRunning = inFlightViewModel.inFlight.value
     assertTrue(isRunning)
   }
 
   @Test
   fun testStopFunction() = runTest {
-    locationViewModel.setFlightId(dbs.flight1.id)
-    locationViewModel.startFlight()
+    inFlightViewModel.setFlightId(dbs.flight1.id)
+    inFlightViewModel.startFlight()
     composeTestRule.waitUntil(timeoutMillis = 2500) {
-      val countString = locationViewModel.counter.value
+      val countString = inFlightViewModel.counter.value
       countString == "00:00:02"
     }
-    locationViewModel.stopFlight()
-    val isRunning = locationViewModel.inFlight.value
+    inFlightViewModel.stopFlight()
+    val isRunning = inFlightViewModel.inFlight.value
     assertFalse(isRunning)
   }
 
   @Test
-  fun testInitialLocationSetup() = runTest { assertNotNull(locationViewModel.currentLocations) }
+  fun testInitialLocationSetup() = runTest { assertNotNull(inFlightViewModel.currentLocations) }
 
   @Test
   fun testLocationUpdate() = runTest {
     val flight = flightTable.get(dbs.flight4.id, onError = { assertNull(it) }) as ConfirmedFlight
 
-    locationViewModel.setFlightId(flight.id)
+    inFlightViewModel.setFlightId(flight.id)
 
-    locationViewModel.startFlight()
+    inFlightViewModel.startFlight()
 
-    locationViewModel.startLocationTracking(flight.team)
+    inFlightViewModel.startLocationTracking(flight.team)
 
     // having the program working with out of order location updates is not a strict requirement
     // but it's still nice to have
-    locationViewModel
+    inFlightViewModel
         .addLocation(Location(userId = dbs.pilot1.id, point = LocationPoint(0, 0.0, 0.0)))
         .join()
-    locationViewModel
+    inFlightViewModel
         .addLocation(Location(userId = dbs.crew1.id, point = LocationPoint(2, 0.0, 0.0)))
         .join()
-    locationViewModel
+    inFlightViewModel
         .addLocation(Location(userId = dbs.crew2.id, point = LocationPoint(2, 0.0, 0.0)))
         .join()
-    locationViewModel
+    inFlightViewModel
         .addLocation(Location(userId = dbs.pilot1.id, point = LocationPoint(3, 0.0, 0.0)))
         .join()
-    locationViewModel
+    inFlightViewModel
         .addLocation(Location(userId = dbs.crew1.id, point = LocationPoint(1, 0.0, 0.0)))
         .join()
-    locationViewModel
+    inFlightViewModel
         .addLocation(Location(userId = dbs.pilot1.id, point = LocationPoint(0, 0.0, 0.0)))
         .join()
 
-    val locations = locationViewModel.currentLocations.value
+    val locations = inFlightViewModel.currentLocations.value
 
     // all the flight members should have an entry as they all have had new updates
     assertEquals(setOf(dbs.pilot1.id, dbs.crew1.id, dbs.crew2.id), locations.keys)
@@ -121,7 +121,7 @@ class LocationViewModelTest {
     assertEquals(2, locations[dbs.crew1.id]!!.second.point.time)
     assertEquals(2, locations[dbs.crew2.id]!!.second.point.time)
 
-    locationViewModel.stopLocationTracking().join()
+    inFlightViewModel.stopLocationTracking().join()
 
     val pilotLocations =
         locationTable.query(Filter.equalTo("userId", dbs.pilot1.id), onError = { assertNull(it) })
@@ -134,28 +134,28 @@ class LocationViewModelTest {
   fun testSaveFlightTrace() = runTest {
     val flight = flightTable.get(dbs.flight4.id, onError = { assertNull(it) }) as ConfirmedFlight
 
-    locationViewModel.setFlightId(flight.id)
-    locationViewModel.startFlight()
+    inFlightViewModel.setFlightId(flight.id)
+    inFlightViewModel.startFlight()
 
     // here we need to have the update in order to have all the locations in the flight trace
     // as the locations that are out of order are discarded (which is a feature not a bug...)
-    locationViewModel
+    inFlightViewModel
         .addLocation(Location(userId = dbs.pilot1.id, point = LocationPoint(0, 12.0, 0.0)))
         .join()
-    locationViewModel
+    inFlightViewModel
         .addLocation(Location(userId = dbs.crew1.id, point = LocationPoint(2, 13.0, 0.0)))
         .join()
-    locationViewModel
+    inFlightViewModel
         .addLocation(Location(userId = dbs.crew2.id, point = LocationPoint(2, -13.03, 0.0)))
         .join()
-    locationViewModel
+    inFlightViewModel
         .addLocation(Location(userId = dbs.pilot1.id, point = LocationPoint(2, 0.0, -12.0)))
         .join()
-    locationViewModel
+    inFlightViewModel
         .addLocation(Location(userId = dbs.pilot1.id, point = LocationPoint(3, 1.0, 0.0)))
         .join()
 
-    locationViewModel.saveFlightTrace().join()
+    inFlightViewModel.saveFlightTrace().join()
 
     val flightTrace = flightTraceTable.get(dbs.flight4.id, onError = { assertNull(it) })
 

--- a/app/src/main/java/ch/epfl/skysync/MainActivity.kt
+++ b/app/src/main/java/ch/epfl/skysync/MainActivity.kt
@@ -12,7 +12,7 @@ import ch.epfl.skysync.components.GlobalSnackbarHost
 import ch.epfl.skysync.database.FirestoreDatabase
 import ch.epfl.skysync.navigation.MainGraph
 import ch.epfl.skysync.ui.theme.SkySyncTheme
-import ch.epfl.skysync.viewmodel.LocationViewModel
+import ch.epfl.skysync.viewmodel.InFlightViewModel
 import ch.epfl.skysync.viewmodel.UserGlobalViewModel
 import com.firebase.ui.auth.FirebaseAuthUIActivityResultContract
 import com.firebase.ui.auth.data.model.FirebaseAuthUIAuthenticationResult
@@ -50,7 +50,7 @@ class MainActivity : ComponentActivity() {
         Scaffold(snackbarHost = { GlobalSnackbarHost() }) {
           userGlobalViewModel = UserGlobalViewModel.createViewModel(repository)
           val inFlightViewModel =
-              LocationViewModel.createViewModel(
+              InFlightViewModel.createViewModel(
                   repository = repository) // is shared between all screens
           MainGraph(
               repository = repository,

--- a/app/src/main/java/ch/epfl/skysync/components/Timer.kt
+++ b/app/src/main/java/ch/epfl/skysync/components/Timer.kt
@@ -8,13 +8,12 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import ch.epfl.skysync.ui.theme.lightOrange
+import ch.epfl.skysync.viewmodel.InFlightViewModel.FlightStage
 
 /**
  * Timer composable that displays the current timer value and a button to start (if the timer is
@@ -22,7 +21,8 @@ import ch.epfl.skysync.ui.theme.lightOrange
  *
  * @param modifier Modifier to apply to this layout node.
  * @param currentTimer The current value of the timer.
- * @param isRunning The current state of the timer.
+ * @param flightStage The current flight stage.
+ * @param isPilot If the user is the pilot of the flight.
  * @param onStart Callback to start the timer.
  * @param onStop Callback to stop the timer.
  */
@@ -30,9 +30,11 @@ import ch.epfl.skysync.ui.theme.lightOrange
 fun Timer(
     modifier: Modifier,
     currentTimer: String,
-    isRunning: Boolean,
+    flightStage: FlightStage,
+    isPilot: Boolean,
     onStart: () -> Unit,
-    onStop: () -> Unit
+    onStop: () -> Unit,
+    onClear: () -> Unit,
 ) {
   Box(
       modifier = modifier.testTag("Timer"),
@@ -42,16 +44,26 @@ fun Timer(
               modifier = Modifier.testTag("Timer Value"),
               text = currentTimer,
               style = MaterialTheme.typography.headlineMedium)
-          if (isRunning) {
-            Button(modifier = Modifier.testTag("Stop Button"), onClick = { onStop() }) {
-              Text(text = "Stop Flight")
-            }
-          } else {
-            Button(
-                modifier = Modifier.testTag("Start Button"),
-                onClick = { onStart() },
-                colors = ButtonDefaults.buttonColors(containerColor = lightOrange)) {
-                  Text(text = "Start Flight")
+
+          when (flightStage) {
+            FlightStage.IDLE ->
+                if (isPilot) {
+                  Button(
+                      modifier = Modifier.testTag("Start Button"),
+                      onClick = { onStart() },
+                      colors = ButtonDefaults.buttonColors(containerColor = lightOrange)) {
+                        Text(text = "Start Flight")
+                      }
+                }
+            FlightStage.ONGOING ->
+                if (isPilot) {
+                  Button(modifier = Modifier.testTag("Stop Button"), onClick = { onStop() }) {
+                    Text(text = "Stop Flight")
+                  }
+                }
+            FlightStage.POST ->
+                Button(modifier = Modifier.testTag("Clear Button"), onClick = { onClear() }) {
+                  Text(text = "Clear Flight")
                 }
           }
         }
@@ -61,5 +73,5 @@ fun Timer(
 @Preview
 @Composable
 fun TimerPreview() {
-  Timer(Modifier.padding(16.dp), "0:0:0", false, {}, {})
+  Timer(Modifier.padding(16.dp), "0:0:0", FlightStage.ONGOING, true, {}, {}, {})
 }

--- a/app/src/main/java/ch/epfl/skysync/database/DateUtility.kt
+++ b/app/src/main/java/ch/epfl/skysync/database/DateUtility.kt
@@ -57,4 +57,13 @@ object DateUtility {
     val formatter = DateTimeFormatter.ofPattern("HH:mm:ss")
     return LocalTime.parse(raw, formatter)
   }
+
+  /** Formats the given time in milliseconds to a string in the format "HH:MM:SS". */
+  fun formatTime(milliseconds: Long): String {
+    val secondsRounded = milliseconds / 1000
+    val hours = secondsRounded / 3600
+    val minutes = (secondsRounded % 3600) / 60
+    val remainingSeconds = secondsRounded % 60
+    return String.format("%02d:%02d:%02d", hours, minutes, remainingSeconds)
+  }
 }

--- a/app/src/main/java/ch/epfl/skysync/database/schemas/FlightSchema.kt
+++ b/app/src/main/java/ch/epfl/skysync/database/schemas/FlightSchema.kt
@@ -9,8 +9,12 @@ import ch.epfl.skysync.models.flight.Flight
 import ch.epfl.skysync.models.flight.FlightColor
 import ch.epfl.skysync.models.flight.PlannedFlight
 import com.google.firebase.firestore.DocumentId
+import com.google.firebase.firestore.PropertyName
 import java.lang.UnsupportedOperationException
 import java.util.Date
+
+// @get:PropertyName("...") is a fix for when a field name gets changed during serialization
+// see: https://stackoverflow.com/questions/38681260/firebase-propertyname-doesnt-work
 
 data class FlightSchema(
     @DocumentId val id: String? = null,
@@ -21,11 +25,7 @@ data class FlightSchema(
     val basketId: String? = null,
     val vehicleIds: List<String>? = null,
     val status: FlightStatus? = null,
-    // Note: this is called numPassengers and not nPassengers because
-    // nPassengers is wrongly mapped to "npassengers" by the firestore class mapper
-    // whereas numPassenger is correctly mapped as "numPassengers"
-    // (which makes no sense but at least it works)
-    val numPassengers: Int? = null,
+    @get:PropertyName("nPassengers") val nPassengers: Int? = null,
     val timeSlot: TimeSlot? = null,
     /** We use the Date class instead of the LocalDate for Firestore see [DateUtility] */
     val date: Date? = null,
@@ -42,7 +42,7 @@ data class FlightSchema(
     /** In: Confirmed flight */
     val meetupLocationPassenger: String? = null,
     /** In: Confirmed flight */
-    val isOngoing: Boolean? = null,
+    @get:PropertyName("isOngoing") val isOngoing: Boolean? = null,
     /** In: Confirmed flight Nullable */
     val startTimestamp: Long? = null,
 ) : Schema<Flight> {
@@ -68,7 +68,7 @@ data class FlightSchema(
           basketId = flight.basket?.id,
           vehicleIds = flight.vehicles.map { it.id },
           status = FlightStatus.PLANNED,
-          numPassengers = flight.nPassengers,
+          nPassengers = flight.nPassengers,
           timeSlot = flight.timeSlot,
           date = DateUtility.localDateToDate(flight.date),
       )
@@ -82,7 +82,7 @@ data class FlightSchema(
           basketId = flight.basket.id,
           vehicleIds = flight.vehicles.map { it.id },
           status = FlightStatus.CONFIRMED,
-          numPassengers = flight.nPassengers,
+          nPassengers = flight.nPassengers,
           timeSlot = flight.timeSlot,
           date = DateUtility.localDateToDate(flight.date),
           remarks = flight.remarks,

--- a/app/src/main/java/ch/epfl/skysync/database/schemas/FlightSchema.kt
+++ b/app/src/main/java/ch/epfl/skysync/database/schemas/FlightSchema.kt
@@ -41,6 +41,10 @@ data class FlightSchema(
     val meetupTimePassenger: String? = null,
     /** In: Confirmed flight */
     val meetupLocationPassenger: String? = null,
+    /** In: Confirmed flight */
+    val isOngoing: Boolean? = null,
+    /** In: Confirmed flight */
+    val startTime: String? = null,
 ) : Schema<Flight> {
   override fun toModel(): Flight {
     throw NotImplementedError()
@@ -49,39 +53,49 @@ data class FlightSchema(
   companion object {
     fun fromModel(model: Flight): FlightSchema {
       return when (model) {
-        is PlannedFlight ->
-            FlightSchema(
-                id = model.id,
-                flightTypeId = model.flightType.id,
-                balloonId = model.balloon?.id,
-                basketId = model.basket?.id,
-                vehicleIds = model.vehicles.map { it.id },
-                status = FlightStatus.PLANNED,
-                numPassengers = model.nPassengers,
-                timeSlot = model.timeSlot,
-                date = DateUtility.localDateToDate(model.date),
-            )
-        is ConfirmedFlight ->
-            FlightSchema(
-                id = model.id,
-                flightTypeId = model.flightType.id,
-                balloonId = model.balloon?.id,
-                basketId = model.basket?.id,
-                vehicleIds = model.vehicles.map { it.id },
-                status = FlightStatus.CONFIRMED,
-                numPassengers = model.nPassengers,
-                timeSlot = model.timeSlot,
-                date = DateUtility.localDateToDate(model.date),
-                remarks = model.remarks,
-                color = model.color,
-                meetupTimeTeam = DateUtility.localTimeToString(model.meetupTimeTeam),
-                departureTimeTeam = DateUtility.localTimeToString(model.departureTimeTeam),
-                meetupTimePassenger = DateUtility.localTimeToString(model.meetupTimePassenger),
-                meetupLocationPassenger = model.meetupLocationPassenger,
-            )
+        is PlannedFlight -> fromPlannedFlight(model)
+        is ConfirmedFlight -> fromConfirmedFlight(model)
         else ->
             throw UnsupportedOperationException("Unexpected class ${model.javaClass.simpleName}")
       }
+    }
+
+    private fun fromPlannedFlight(flight: PlannedFlight): FlightSchema {
+      return FlightSchema(
+          id = flight.id,
+          flightTypeId = flight.flightType.id,
+          balloonId = flight.balloon?.id,
+          basketId = flight.basket?.id,
+          vehicleIds = flight.vehicles.map { it.id },
+          status = FlightStatus.PLANNED,
+          numPassengers = flight.nPassengers,
+          timeSlot = flight.timeSlot,
+          date = DateUtility.localDateToDate(flight.date),
+      )
+    }
+
+    private fun fromConfirmedFlight(flight: ConfirmedFlight): FlightSchema {
+      return FlightSchema(
+          id = flight.id,
+          flightTypeId = flight.flightType.id,
+          balloonId = flight.balloon.id,
+          basketId = flight.basket.id,
+          vehicleIds = flight.vehicles.map { it.id },
+          status = FlightStatus.CONFIRMED,
+          numPassengers = flight.nPassengers,
+          timeSlot = flight.timeSlot,
+          date = DateUtility.localDateToDate(flight.date),
+          remarks = flight.remarks,
+          color = flight.color,
+          meetupTimeTeam = DateUtility.localTimeToString(flight.meetupTimeTeam),
+          departureTimeTeam = DateUtility.localTimeToString(flight.departureTimeTeam),
+          meetupTimePassenger = DateUtility.localTimeToString(flight.meetupTimePassenger),
+          meetupLocationPassenger = flight.meetupLocationPassenger,
+          isOngoing = flight.isOngoing,
+          startTime =
+              if (flight.startTime != null) DateUtility.localTimeToString(flight.startTime)
+              else null,
+      )
     }
   }
 }

--- a/app/src/main/java/ch/epfl/skysync/database/schemas/FlightSchema.kt
+++ b/app/src/main/java/ch/epfl/skysync/database/schemas/FlightSchema.kt
@@ -43,8 +43,8 @@ data class FlightSchema(
     val meetupLocationPassenger: String? = null,
     /** In: Confirmed flight */
     val isOngoing: Boolean? = null,
-    /** In: Confirmed flight */
-    val startTime: String? = null,
+    /** In: Confirmed flight Nullable */
+    val startTimestamp: Long? = null,
 ) : Schema<Flight> {
   override fun toModel(): Flight {
     throw NotImplementedError()
@@ -92,9 +92,7 @@ data class FlightSchema(
           meetupTimePassenger = DateUtility.localTimeToString(flight.meetupTimePassenger),
           meetupLocationPassenger = flight.meetupLocationPassenger,
           isOngoing = flight.isOngoing,
-          startTime =
-              if (flight.startTime != null) DateUtility.localTimeToString(flight.startTime)
-              else null,
+          startTimestamp = flight.startTimestamp,
       )
     }
   }

--- a/app/src/main/java/ch/epfl/skysync/database/tables/FlightTable.kt
+++ b/app/src/main/java/ch/epfl/skysync/database/tables/FlightTable.kt
@@ -3,6 +3,7 @@ package ch.epfl.skysync.database.tables
 import ch.epfl.skysync.database.DateUtility
 import ch.epfl.skysync.database.FirestoreDatabase
 import ch.epfl.skysync.database.FlightStatus
+import ch.epfl.skysync.database.ListenerUpdate
 import ch.epfl.skysync.database.Table
 import ch.epfl.skysync.database.schemas.FlightMemberSchema
 import ch.epfl.skysync.database.schemas.FlightSchema
@@ -16,8 +17,11 @@ import ch.epfl.skysync.models.flight.Role
 import ch.epfl.skysync.models.flight.Team
 import ch.epfl.skysync.models.flight.Vehicle
 import ch.epfl.skysync.models.user.User
+import com.google.firebase.firestore.FieldPath
 import com.google.firebase.firestore.Filter
+import com.google.firebase.firestore.ListenerRegistration
 import com.google.firebase.firestore.Query
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -75,10 +79,50 @@ class FlightTable(db: FirestoreDatabase) :
             meetupTimeTeam = DateUtility.stringToLocalTime(schema.meetupTimeTeam!!),
             departureTimeTeam = DateUtility.stringToLocalTime(schema.departureTimeTeam!!),
             meetupTimePassenger = DateUtility.stringToLocalTime(schema.meetupTimePassenger!!),
-            meetupLocationPassenger = schema.meetupLocationPassenger!!)
+            meetupLocationPassenger = schema.meetupLocationPassenger!!,
+            isOngoing = schema.isOngoing!!,
+            startTimestamp = schema.startTimestamp,
+        )
       }
       FlightStatus.FINISHED -> throw NotImplementedError()
     }
+  }
+
+  /**
+   * Add a listener on a flight
+   *
+   * The listener will be triggered each time the flight is updated.
+   *
+   * @param flightId The ID of the flight
+   * @param onChange Callback called each time the listener is triggered, passed the adds, updates,
+   *   deletes that happened since the last listener trigger.
+   */
+  fun addFlightListener(
+      flightId: String,
+      onChange: suspend (ListenerUpdate<Flight>) -> Unit,
+      coroutineScope: CoroutineScope,
+      onError: ((Exception) -> Unit)? = null
+  ): ListenerRegistration {
+    return queryListener(
+        Filter.equalTo(FieldPath.documentId(), flightId),
+        onChange = { update ->
+          coroutineScope {
+            withErrorCallback(onError) {
+              val adds = update.adds.map { async { retrieveFlight(it) } }
+              val updates = update.updates.map { async { retrieveFlight(it) } }
+              val deletes = update.deletes.map { async { retrieveFlight(it) } }
+              onChange(
+                  ListenerUpdate(
+                      isFirstUpdate = update.isFirstUpdate,
+                      isLocalUpdate = update.isLocalUpdate,
+                      adds = adds.awaitAll().filterNotNull(),
+                      updates = updates.awaitAll().filterNotNull(),
+                      deletes = deletes.awaitAll().filterNotNull(),
+                  ))
+            }
+          }
+        },
+        coroutineScope = coroutineScope)
   }
 
   /**

--- a/app/src/main/java/ch/epfl/skysync/database/tables/FlightTable.kt
+++ b/app/src/main/java/ch/epfl/skysync/database/tables/FlightTable.kt
@@ -51,7 +51,7 @@ class FlightTable(db: FirestoreDatabase) :
       FlightStatus.PLANNED ->
           PlannedFlight(
               id = schema.id!!,
-              nPassengers = schema.numPassengers!!,
+              nPassengers = schema.nPassengers!!,
               team = team,
               flightType = flightType,
               balloon = balloon,
@@ -66,7 +66,7 @@ class FlightTable(db: FirestoreDatabase) :
         }
         ConfirmedFlight(
             id = schema.id!!,
-            nPassengers = schema.numPassengers!!,
+            nPassengers = schema.nPassengers!!,
             team = team,
             flightType = flightType,
             balloon = balloon,

--- a/app/src/main/java/ch/epfl/skysync/models/flight/ConfirmedFlight.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/flight/ConfirmedFlight.kt
@@ -20,6 +20,8 @@ data class ConfirmedFlight(
     val departureTimeTeam: LocalTime,
     val meetupTimePassenger: LocalTime,
     val meetupLocationPassenger: String,
+    val isOngoing: Boolean = false,
+    val startTime: LocalTime? = null,
 ) : Flight {
   override fun getFlightStatus(): FlightStatus {
     return FlightStatus.CONFIRMED

--- a/app/src/main/java/ch/epfl/skysync/models/flight/ConfirmedFlight.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/flight/ConfirmedFlight.kt
@@ -21,7 +21,7 @@ data class ConfirmedFlight(
     val meetupTimePassenger: LocalTime,
     val meetupLocationPassenger: String,
     val isOngoing: Boolean = false,
-    val startTime: LocalTime? = null,
+    val startTimestamp: Long? = null,
 ) : Flight {
   override fun getFlightStatus(): FlightStatus {
     return FlightStatus.CONFIRMED

--- a/app/src/main/java/ch/epfl/skysync/models/flight/Team.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/flight/Team.kt
@@ -22,6 +22,12 @@ data class Team(val roles: List<Role>) {
     return roles.mapNotNull { it.assignedUser }
   }
 
+  /** Returns if the user has the given role in the team */
+  fun hasUserRole(roleType: RoleType, userId: String): Boolean {
+    return roles.find { role -> role.roleType == roleType && role.assignedUser?.id == userId } !=
+        null
+  }
+
   /** assigns the given user to the first role with the given role type */
   fun assign(user: User, roleType: RoleType): Team {
     // Todo: to be implemented

--- a/app/src/main/java/ch/epfl/skysync/navigation/AdminGraph.kt
+++ b/app/src/main/java/ch/epfl/skysync/navigation/AdminGraph.kt
@@ -24,14 +24,14 @@ import ch.epfl.skysync.screens.admin.ModifyFlightScreen
 import ch.epfl.skysync.screens.admin.UserManagementScreen
 import ch.epfl.skysync.viewmodel.ChatViewModel
 import ch.epfl.skysync.viewmodel.FlightsViewModel
-import ch.epfl.skysync.viewmodel.LocationViewModel
+import ch.epfl.skysync.viewmodel.InFlightViewModel
 import ch.epfl.skysync.viewmodel.MessageListenerSharedViewModel
 
 fun NavGraphBuilder.adminGraph(
     repository: Repository,
     navController: NavHostController,
     uid: String?,
-    locationViewModel: LocationViewModel? = null
+    inFlightViewModel: InFlightViewModel? = null
 ) {
   navigation(startDestination = Route.ADMIN_HOME, route = Route.ADMIN) {
     adminpersonalCalendar(repository, navController, uid)

--- a/app/src/main/java/ch/epfl/skysync/navigation/CrewPilotGraph.kt
+++ b/app/src/main/java/ch/epfl/skysync/navigation/CrewPilotGraph.kt
@@ -33,7 +33,7 @@ import ch.epfl.skysync.screens.reports.CrewReportScreen
 import ch.epfl.skysync.screens.reports.PilotReportScreen
 import ch.epfl.skysync.viewmodel.ChatViewModel
 import ch.epfl.skysync.viewmodel.FlightsViewModel
-import ch.epfl.skysync.viewmodel.LocationViewModel
+import ch.epfl.skysync.viewmodel.InFlightViewModel
 import ch.epfl.skysync.viewmodel.MessageListenerSharedViewModel
 import java.time.LocalDate
 import java.util.Date
@@ -42,7 +42,7 @@ fun NavGraphBuilder.crewPilotGraph(
     repository: Repository,
     navController: NavHostController,
     uid: String?,
-    locationViewModel: LocationViewModel? = null
+    inFlightViewModel: InFlightViewModel? = null
 ) {
   navigation(startDestination = Route.CREW_HOME, route = Route.CREW_PILOT) {
     personalCalendar(repository, navController, uid)
@@ -74,6 +74,10 @@ fun NavGraphBuilder.crewPilotGraph(
         }
     composable(Route.CREW_HOME) { entry ->
 
+      // initiate in flight view model here, so that we can notify
+      // the user when a flight is started by someone else
+      inFlightViewModel!!.init(uid!!)
+
       // get the MessageListenerSharedViewModel here so that it gets
       // instantiated
       val messageListenerSharedViewModel =
@@ -97,13 +101,7 @@ fun NavGraphBuilder.crewPilotGraph(
           ChatViewModel.createViewModel(uid!!, messageListenerSharedViewModel, repository)
       ChatScreen(navController, chatViewModel)
     }
-    composable(Route.FLIGHT) {
-      if (locationViewModel!!.userId == null) {
-        locationViewModel.userId = uid!!
-      }
-      locationViewModel.refreshPersonalFlights()
-      FlightScreen(navController, locationViewModel, uid!!)
-    }
+    composable(Route.FLIGHT) { FlightScreen(navController, inFlightViewModel!!, uid!!) }
     composable(Route.PILOT_REPORT) {
       // TODO remove when done with viewModel
       val pilot =

--- a/app/src/main/java/ch/epfl/skysync/navigation/HomeGraph.kt
+++ b/app/src/main/java/ch/epfl/skysync/navigation/HomeGraph.kt
@@ -16,18 +16,18 @@ import ch.epfl.skysync.models.message.Message
 import ch.epfl.skysync.models.message.MessageGroup
 import ch.epfl.skysync.screens.LoadingScreen
 import ch.epfl.skysync.viewmodel.FlightsViewModel
-import ch.epfl.skysync.viewmodel.LocationViewModel
+import ch.epfl.skysync.viewmodel.InFlightViewModel
 
 /** Graph of the main screens of the app */
 fun NavGraphBuilder.homeGraph(
     repository: Repository,
     navController: NavHostController,
     uid: String?,
-    locationViewModel: LocationViewModel? = null
+    inFlightViewModel: InFlightViewModel? = null
 ) {
   navigation(startDestination = Route.LOADING, route = Route.MAIN) {
-    adminGraph(repository, navController, uid, locationViewModel)
-    crewPilotGraph(repository, navController, uid, locationViewModel)
+    adminGraph(repository, navController, uid, inFlightViewModel)
+    crewPilotGraph(repository, navController, uid, inFlightViewModel)
     composable(Route.LOADING) {
       val flightsOverviewViewModel = FlightsViewModel.createViewModel(repository, uid)
       flightsOverviewViewModel.refresh()

--- a/app/src/main/java/ch/epfl/skysync/navigation/MainGraph.kt
+++ b/app/src/main/java/ch/epfl/skysync/navigation/MainGraph.kt
@@ -10,7 +10,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import ch.epfl.skysync.Repository
 import ch.epfl.skysync.screens.LoginScreen
-import ch.epfl.skysync.viewmodel.LocationViewModel
+import ch.epfl.skysync.viewmodel.InFlightViewModel
 import ch.epfl.skysync.viewmodel.UserGlobalViewModel
 
 /** Graph of the whole navigation of the app */
@@ -19,7 +19,7 @@ fun MainGraph(
     repository: Repository,
     navHostController: NavHostController,
     signInLauncher: ActivityResultLauncher<Intent>,
-    inFlightsViewModel: LocationViewModel? = null,
+    inFlightsViewModel: InFlightViewModel? = null,
     userGlobalViewModel: UserGlobalViewModel,
 ) {
   val user by userGlobalViewModel.user.collectAsStateWithLifecycle()

--- a/app/src/main/java/ch/epfl/skysync/screens/crewpilot/Flight.kt
+++ b/app/src/main/java/ch/epfl/skysync/screens/crewpilot/Flight.kt
@@ -48,7 +48,7 @@ import ch.epfl.skysync.models.user.User
 import ch.epfl.skysync.navigation.BottomBar
 import ch.epfl.skysync.ui.theme.lightOrange
 import ch.epfl.skysync.ui.theme.lightViolet
-import ch.epfl.skysync.viewmodel.LocationViewModel
+import ch.epfl.skysync.viewmodel.InFlightViewModel
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
@@ -116,13 +116,13 @@ fun ShowFlightToStart(
 @Composable
 fun FlightScreen(
     navController: NavHostController,
-    inFlightViewModel: LocationViewModel,
+    inFlightViewModel: InFlightViewModel,
     uid: String
 ) {
   val rawTime by inFlightViewModel.rawCounter.collectAsStateWithLifecycle()
   val currentTime by inFlightViewModel.counter.collectAsStateWithLifecycle()
   val flightIsStarted by inFlightViewModel.inFlight.collectAsStateWithLifecycle()
-  val personalFlights by inFlightViewModel.personalFlights.collectAsStateWithLifecycle()
+  val personalFlights by inFlightViewModel.confirmedFlights.collectAsStateWithLifecycle()
   val currentFlightId by inFlightViewModel.flightId.collectAsStateWithLifecycle()
 
   val currentLocations = inFlightViewModel.currentLocations.collectAsState().value

--- a/app/src/main/java/ch/epfl/skysync/screens/crewpilot/Flight.kt
+++ b/app/src/main/java/ch/epfl/skysync/screens/crewpilot/Flight.kt
@@ -75,6 +75,7 @@ fun ShowFlightToStart(
     flight: ConfirmedFlight?,
     onClick: (String) -> Unit
 ) {
+  println("FLIGHT CARD ${flight?.id}")
   Scaffold(modifier = Modifier.fillMaxSize(), bottomBar = { BottomBar(navController) }) { padding ->
     // Renders the Google Map or a permission request message based on the permission status.
     Column(modifier = Modifier.fillMaxSize().padding(padding).testTag("FlightLaunch")) {
@@ -123,7 +124,7 @@ fun FlightScreen(
   val rawTime by inFlightViewModel.rawCounter.collectAsStateWithLifecycle()
   val currentTime by inFlightViewModel.counter.collectAsStateWithLifecycle()
   val flightStage by inFlightViewModel.flightStage.collectAsStateWithLifecycle()
-  val confirmedFlights by inFlightViewModel.confirmedFlights.collectAsStateWithLifecycle()
+  val startableFlights by inFlightViewModel.startableFlights.collectAsStateWithLifecycle()
   val currentFlight by inFlightViewModel.currentFlight.collectAsStateWithLifecycle()
 
   val currentLocations = inFlightViewModel.currentLocations.collectAsState().value
@@ -182,6 +183,9 @@ fun FlightScreen(
     // Cleanup function to stop receiving location updates when the composable is disposed.
     onDispose { fusedLocationClient.removeLocationUpdates(locationCallback) }
   }
+  println(
+      "Loading: $loading isPilot: ${inFlightViewModel.isPilot()} currentFlight: ${currentFlight?.id} startableFlights: ${startableFlights.size}")
+  println("Permission: ${locationPermission.status.isGranted}")
   if (!locationPermission.status.isGranted) {
     Box(modifier = Modifier.fillMaxSize().padding(16.dp), contentAlignment = Alignment.Center) {
       Column(horizontalAlignment = Alignment.CenterHorizontally) {
@@ -191,12 +195,8 @@ fun FlightScreen(
     }
   } else if (loading) {
     LoadingComponent(isLoading = true, onRefresh = {}) {}
-  } else if (!inFlightViewModel.isPilot()) {
-    // TODO: Show screen for crew
-  } else if (confirmedFlights.isEmpty()) {
-    ShowFlightToStart(navController = navController, flight = null) {}
   } else if (currentFlight == null) {
-    ShowFlightToStart(navController, confirmedFlights.first()) {
+    ShowFlightToStart(navController, startableFlights.firstOrNull()) {
       inFlightViewModel.setCurrentFlight(it)
     }
   } else {

--- a/app/src/main/java/ch/epfl/skysync/screens/crewpilot/Flight.kt
+++ b/app/src/main/java/ch/epfl/skysync/screens/crewpilot/Flight.kt
@@ -124,7 +124,7 @@ fun FlightScreen(
   val rawTime by inFlightViewModel.rawCounter.collectAsStateWithLifecycle()
   val currentTime by inFlightViewModel.counter.collectAsStateWithLifecycle()
   val flightStage by inFlightViewModel.flightStage.collectAsStateWithLifecycle()
-  val startableFlights by inFlightViewModel.startableFlights.collectAsStateWithLifecycle()
+  val startableFlight by inFlightViewModel.startableFlight.collectAsStateWithLifecycle()
   val currentFlight by inFlightViewModel.currentFlight.collectAsStateWithLifecycle()
 
   val currentLocations = inFlightViewModel.currentLocations.collectAsState().value
@@ -183,9 +183,7 @@ fun FlightScreen(
     // Cleanup function to stop receiving location updates when the composable is disposed.
     onDispose { fusedLocationClient.removeLocationUpdates(locationCallback) }
   }
-  println(
-      "Loading: $loading isPilot: ${inFlightViewModel.isPilot()} currentFlight: ${currentFlight?.id} startableFlights: ${startableFlights.size}")
-  println("Permission: ${locationPermission.status.isGranted}")
+
   if (!locationPermission.status.isGranted) {
     Box(modifier = Modifier.fillMaxSize().padding(16.dp), contentAlignment = Alignment.Center) {
       Column(horizontalAlignment = Alignment.CenterHorizontally) {
@@ -196,9 +194,7 @@ fun FlightScreen(
   } else if (loading) {
     LoadingComponent(isLoading = true, onRefresh = {}) {}
   } else if (currentFlight == null) {
-    ShowFlightToStart(navController, startableFlights.firstOrNull()) {
-      inFlightViewModel.setCurrentFlight(it)
-    }
+    ShowFlightToStart(navController, startableFlight) { inFlightViewModel.setCurrentFlight(it) }
   } else {
     Scaffold(
         modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/ch/epfl/skysync/viewmodel/InFlightViewModel.kt
+++ b/app/src/main/java/ch/epfl/skysync/viewmodel/InFlightViewModel.kt
@@ -495,6 +495,8 @@ class InFlightViewModel(val repository: Repository) : ViewModel() {
   }
 
   override fun onCleared() {
+    flightListeners.forEach { it.remove() }
+    flightListeners.clear()
     stopLocationTracking()
     stopTimer()
     viewModelScope.launch { clearLocationTracking() }


### PR DESCRIPTION
* Rename `LocationViewModel` to `InFlightViewModel`
* `InFlightViewModel` has 3 stages `IDLE`, `ONGOING`, `POST`, the `POST` stage is new, it is when the flight is finished (when the balloon touch the ground) but the user want to stay on the flight screen (to see the balloon on the map), in this stage everything is static. There is now 3 buttons `Start Flight`, `Stop Flight` and `Clear Flight` which switch from `POST` to `IDLE`, clear all data about the current flight.
* Only the pilot can start, stop, clear a flight
* Add a listener to be notified when a flight is started/stopped

Close #321
Close #322