### PR TITLE
Integrate finished flight in inFlightVm

### DIFF
--- a/app/src/androidTest/java/ch/epfl/skysync/database/tables/FlightTableUnitTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/database/tables/FlightTableUnitTest.kt
@@ -2,24 +2,28 @@ package ch.epfl.skysync.database.tables
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.epfl.skysync.database.DatabaseSetup
+import ch.epfl.skysync.database.DateUtility
 import ch.epfl.skysync.database.FirestoreDatabase
 import ch.epfl.skysync.models.flight.Role
 import ch.epfl.skysync.models.flight.RoleType
 import ch.epfl.skysync.models.flight.Team
 import ch.epfl.skysync.models.location.FlightTrace
 import ch.epfl.skysync.models.location.LocationPoint
+import ch.epfl.skysync.models.reports.FlightReport
 import java.time.LocalTime
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.time.LocalDate
 
 @RunWith(AndroidJUnit4::class)
 class FlightTableUnitTest {
   private val db = FirestoreDatabase(useEmulator = true)
   private val dbs = DatabaseSetup()
   private val flightTable = FlightTable(db)
+    private val reportTable = ReportTable(db)
   private val flightMemberTable = FlightMemberTable(db)
 
   @Before
@@ -30,7 +34,7 @@ class FlightTableUnitTest {
 
   @Test
   fun addAndRetrieveFinishFlight() = runTest {
-    val finishedFlight =
+    var finishedFlight =
         dbs.flight4.finishFlight(
             takeOffTime = LocalTime.of(12, 0, 0),
             landingTime = LocalTime.of(14, 0, 0),
@@ -38,7 +42,26 @@ class FlightTableUnitTest {
             landingLocation = LocationPoint(0, 0.1, 0.1, "LandingSpot"),
             flightTime = 2,
             flightTrace = FlightTrace(dbs.flight4.id, listOf()))
+      var report1 = FlightReport(
+          author = "ME",
+          begin = DateUtility.localDateAndTimeToDate(
+              LocalDate.of(2021, 1, 1),
+              LocalTime.of(12, 0, 0),
+          ),
+          end = DateUtility.localDateAndTimeToDate(
+              LocalDate.of(2021, 1, 1),
+              LocalTime.of(12, 2, 0),
+          ),
+          pauseDuration = 10,
+          comments = "hola",
+      )
+      finishedFlight = finishedFlight.copy(reportId = listOf(report1))
     flightTable.update(dbs.flight4.id, finishedFlight, onError = { assertNull(it) })
+      val foundReports = reportTable.retrieveReports(dbs.flight4.id)
+        assertEquals(1, foundReports.size)
+      val reportId = foundReports[0].id
+      report1 = report1.copy(id = reportId)
+      finishedFlight = finishedFlight.copy(reportId = listOf(report1))
     val retrievedFlight = flightTable.get(dbs.flight4.id, onError = { assertNull(it) })
     assertEquals(finishedFlight, retrievedFlight)
   }

--- a/app/src/androidTest/java/ch/epfl/skysync/database/tables/FlightTableUnitTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/database/tables/FlightTableUnitTest.kt
@@ -10,20 +10,20 @@ import ch.epfl.skysync.models.flight.Team
 import ch.epfl.skysync.models.location.FlightTrace
 import ch.epfl.skysync.models.location.LocationPoint
 import ch.epfl.skysync.models.reports.FlightReport
+import java.time.LocalDate
 import java.time.LocalTime
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.time.LocalDate
 
 @RunWith(AndroidJUnit4::class)
 class FlightTableUnitTest {
   private val db = FirestoreDatabase(useEmulator = true)
   private val dbs = DatabaseSetup()
   private val flightTable = FlightTable(db)
-    private val reportTable = ReportTable(db)
+  private val reportTable = ReportTable(db)
   private val flightMemberTable = FlightMemberTable(db)
 
   @Before
@@ -42,26 +42,29 @@ class FlightTableUnitTest {
             landingLocation = LocationPoint(0, 0.1, 0.1, "LandingSpot"),
             flightTime = 2,
             flightTrace = FlightTrace(dbs.flight4.id, listOf()))
-      var report1 = FlightReport(
-          author = "ME",
-          begin = DateUtility.localDateAndTimeToDate(
-              LocalDate.of(2021, 1, 1),
-              LocalTime.of(12, 0, 0),
-          ),
-          end = DateUtility.localDateAndTimeToDate(
-              LocalDate.of(2021, 1, 1),
-              LocalTime.of(12, 2, 0),
-          ),
-          pauseDuration = 10,
-          comments = "hola",
-      )
-      finishedFlight = finishedFlight.copy(reportId = listOf(report1))
+    var report1 =
+        FlightReport(
+            author = "ME",
+            begin =
+                DateUtility.localDateAndTimeToDate(
+                    LocalDate.of(2021, 1, 1),
+                    LocalTime.of(12, 0, 0),
+                ),
+            end =
+                DateUtility.localDateAndTimeToDate(
+                    LocalDate.of(2021, 1, 1),
+                    LocalTime.of(12, 2, 0),
+                ),
+            pauseDuration = 10,
+            comments = "hola",
+        )
+    finishedFlight = finishedFlight.copy(reportId = listOf(report1))
     flightTable.update(dbs.flight4.id, finishedFlight, onError = { assertNull(it) })
-      val foundReports = reportTable.retrieveReports(dbs.flight4.id)
-        assertEquals(1, foundReports.size)
-      val reportId = foundReports[0].id
-      report1 = report1.copy(id = reportId)
-      finishedFlight = finishedFlight.copy(reportId = listOf(report1))
+    val foundReports = reportTable.retrieveReports(dbs.flight4.id)
+    assertEquals(1, foundReports.size)
+    val reportId = foundReports[0].id
+    report1 = report1.copy(id = reportId)
+    finishedFlight = finishedFlight.copy(reportId = listOf(report1))
     val retrievedFlight = flightTable.get(dbs.flight4.id, onError = { assertNull(it) })
     assertEquals(finishedFlight, retrievedFlight)
   }

--- a/app/src/androidTest/java/ch/epfl/skysync/test_end_to_end/E2EPilotDuringFlight.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/test_end_to_end/E2EPilotDuringFlight.kt
@@ -76,77 +76,77 @@ class E2EPilotDuringFlight {
   }
 
   @Test
-  fun useMapAndChatAsPilot() {
-    runTest {
-      // Refreshes chat and user data asynchronously
-      chatViewModel.refresh().join()
-      chatViewModel.refreshUser().join()
-      inFlightViewModel.init(dbs.pilot1.id).join()
+  fun useMapAndChatAsPilot() = runTest {
+    // Refreshes chat and user data asynchronously
+    chatViewModel.refresh().join()
+    chatViewModel.refreshUser().join()
+    inFlightViewModel.init(dbs.pilot1.id).join()
 
-      // Clicks on the "Flight" button to navigate to the flight screen
-      composeTestRule.onNodeWithText("Flight").performClick()
-      var route = navController.currentBackStackEntry?.destination?.route
-      Assert.assertEquals(Route.LAUNCH_FLIGHT, route)
-      println("FLIGHTS ${listOf(dbs.flight1.id, dbs.flight2.id, dbs.flight3.id, dbs.flight4.id)}")
-      var usedFlightId = ""
-      for (f in listOf(dbs.flight1, dbs.flight2, dbs.flight3, dbs.flight4)) {
-        if (composeTestRule.onNodeWithTag("flightCard${f.id}").isDisplayed()) {
-          usedFlightId = f.id
-          break
-        }
+    // Clicks on the "Flight" button to navigate to the flight screen
+    composeTestRule.onNodeWithText("Flight").performClick()
+    var route = navController.currentBackStackEntry?.destination?.route
+    Assert.assertEquals(Route.LAUNCH_FLIGHT, route)
+    println("FLIGHTS ${listOf(dbs.flight1.id, dbs.flight2.id, dbs.flight3.id, dbs.flight4.id)}")
+    var usedFlightId = ""
+    for (f in listOf(dbs.flight1, dbs.flight2, dbs.flight3, dbs.flight4)) {
+      if (composeTestRule.onNodeWithTag("flightCard${f.id}").isDisplayed()) {
+        usedFlightId = f.id
+        break
       }
-      composeTestRule.onNodeWithTag("flightCard${usedFlightId}").performClick()
-
-      // Asserts the presence of the timer
-      composeTestRule.waitUntil(3000) { composeTestRule.onNodeWithTag("Timer").isDisplayed() }
-
-      // Starts the timer by clicking on the "Start Button"
-      composeTestRule.onNodeWithTag("Start Button").performClick()
-
-      // Asserts the presence of the map and "Locate Me" button
-      composeTestRule.onNodeWithTag("Map").assertExists()
-      composeTestRule.onNodeWithContentDescription("Locate Me").assertIsDisplayed()
-
-      // Opens flight information and asserts the display of navigation information
-      composeTestRule.onNodeWithContentDescription("Flight infos").performClick()
-      composeTestRule
-          .onNodeWithText(
-              "Horizontal Speed: 0.00 m/s\nVertical Speed: 0.00 m/s\nAltitude: 0 m\nBearing: 0.00 °")
-          .assertIsDisplayed()
-
-      // Navigates to the chat screen
-      composeTestRule.onNodeWithText("Chat").performClick()
-      route = navController.currentBackStackEntry?.destination?.route
-      Assert.assertEquals(Route.CREW_CHAT, route)
-
-      // Refreshes chat data asynchronously
-      val index = 0
-      chatViewModel.refresh().join()
-      chatViewModel.refreshUser().join()
-
-      // Waits for the UI to become idle
-      composeTestRule.waitForIdle()
-
-      // clicks on group chat
-      composeTestRule.waitUntil(2500) {
-        composeTestRule.onAllNodesWithTag("GroupCard$index").fetchSemanticsNodes().isNotEmpty()
-      }
-      composeTestRule.onNodeWithTag("GroupCard$index").performClick()
-
-      // Inputs and sends a message
-      composeTestRule.onNodeWithTag("ChatInput").performTextInput("Hello")
-      composeTestRule.onNodeWithTag("SendButton").performClick()
-
-      // Returns to the flight screen with the timer still running
-      composeTestRule.onNodeWithText("Flight").performClick()
-      composeTestRule.waitForIdle()
-      route = navController.currentBackStackEntry?.destination?.route
-      Assert.assertEquals(Route.FLIGHT, route)
-
-      // Stops the timer by clicking on the "Stop Button"
-      composeTestRule.onNodeWithTag("Stop Button").performClick()
-      route = navController.currentBackStackEntry?.destination?.route
-      Assert.assertEquals(Route.CREW_HOME, route)
     }
+    composeTestRule.onNodeWithTag("flightCard${usedFlightId}").performClick()
+
+    // Asserts the presence of the timer
+    composeTestRule.waitUntil(3000) { composeTestRule.onNodeWithTag("Timer").isDisplayed() }
+
+    // Starts the timer by clicking on the "Start Button"
+    composeTestRule.onNodeWithTag("Start Button").performClick()
+
+    // Asserts the presence of the map and "Locate Me" button
+    composeTestRule.onNodeWithTag("Map").assertExists()
+    composeTestRule.onNodeWithContentDescription("Locate Me").assertIsDisplayed()
+
+    // Opens flight information and asserts the display of navigation information
+    composeTestRule.onNodeWithContentDescription("Flight infos").performClick()
+    composeTestRule
+        .onNodeWithText(
+            "Horizontal Speed: 0.00 m/s\nVertical Speed: 0.00 m/s\nAltitude: 0 m\nBearing: 0.00 °")
+        .assertIsDisplayed()
+
+    // Navigates to the chat screen
+    composeTestRule.onNodeWithText("Chat").performClick()
+    route = navController.currentBackStackEntry?.destination?.route
+    Assert.assertEquals(Route.CREW_CHAT, route)
+
+    // Refreshes chat data asynchronously
+    val index = 0
+    chatViewModel.refresh().join()
+    chatViewModel.refreshUser().join()
+
+    // Waits for the UI to become idle
+    composeTestRule.waitForIdle()
+
+    // clicks on group chat
+    composeTestRule.waitUntil(2500) {
+      composeTestRule.onAllNodesWithTag("GroupCard$index").fetchSemanticsNodes().isNotEmpty()
+    }
+    composeTestRule.onNodeWithTag("GroupCard$index").performClick()
+
+    // Inputs and sends a message
+    composeTestRule.onNodeWithTag("ChatInput").performTextInput("Hello")
+    composeTestRule.onNodeWithTag("SendButton").performClick()
+
+    // Returns to the flight screen with the timer still running
+    composeTestRule.onNodeWithText("Flight").performClick()
+    composeTestRule.waitForIdle()
+    route = navController.currentBackStackEntry?.destination?.route
+    Assert.assertEquals(Route.FLIGHT, route)
+
+    // Stops the timer by clicking on the "Stop Button"
+    composeTestRule.onNodeWithTag("Stop Button").performClick()
+    composeTestRule.waitUntil(3000) { composeTestRule.onNodeWithTag("Clear Button").isDisplayed() }
+    composeTestRule.onNodeWithTag("Clear Button").performClick()
+    route = navController.currentBackStackEntry?.destination?.route
+    Assert.assertEquals(Route.CREW_HOME, route)
   }
 }

--- a/app/src/androidTest/java/ch/epfl/skysync/test_end_to_end/E2EPilotDuringFlight.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/test_end_to_end/E2EPilotDuringFlight.kt
@@ -89,10 +89,9 @@ class E2EPilotDuringFlight {
     var usedFlightId = ""
     composeTestRule.waitUntil(3000) {
       composeTestRule.onNodeWithTag("flightCard${dbs.flight1.id}").isDisplayed() ||
-        composeTestRule.onNodeWithTag("flightCard${dbs.flight2.id}").isDisplayed() ||
-        composeTestRule.onNodeWithTag("flightCard${dbs.flight3.id}").isDisplayed() ||
-        composeTestRule.onNodeWithTag("flightCard${dbs.flight4.id}").isDisplayed()
-
+          composeTestRule.onNodeWithTag("flightCard${dbs.flight2.id}").isDisplayed() ||
+          composeTestRule.onNodeWithTag("flightCard${dbs.flight3.id}").isDisplayed() ||
+          composeTestRule.onNodeWithTag("flightCard${dbs.flight4.id}").isDisplayed()
     }
     for (f in listOf(dbs.flight1, dbs.flight2, dbs.flight3, dbs.flight4)) {
       if (composeTestRule.onNodeWithTag("flightCard${f.id}").isDisplayed()) {
@@ -109,8 +108,8 @@ class E2EPilotDuringFlight {
     composeTestRule.onNodeWithTag("Start Button").performClick()
 
     // Asserts the presence of the map and "Locate Me" button
-    composeTestRule.waitUntil(3000){
-            composeTestRule.onNodeWithContentDescription("Locate Me").isDisplayed()
+    composeTestRule.waitUntil(3000) {
+      composeTestRule.onNodeWithContentDescription("Locate Me").isDisplayed()
     }
 
     // Opens flight information and asserts the display of navigation information
@@ -145,9 +144,7 @@ class E2EPilotDuringFlight {
 
     // Returns to the flight screen with the timer still running
     composeTestRule.onNodeWithText("Flight").performClick()
-    composeTestRule.waitUntil(3000) {
-      composeTestRule.onNodeWithTag("Stop Button").isDisplayed()
-    }
+    composeTestRule.waitUntil(3000) { composeTestRule.onNodeWithTag("Stop Button").isDisplayed() }
     route = navController.currentBackStackEntry?.destination?.route
     Assert.assertEquals(Route.FLIGHT, route)
 
@@ -156,7 +153,7 @@ class E2EPilotDuringFlight {
     composeTestRule.waitUntil(3000) { composeTestRule.onNodeWithTag("Clear Button").isDisplayed() }
     composeTestRule.onNodeWithTag("Clear Button").performClick()
     composeTestRule.waitUntil(3000) {
-        composeTestRule.onNodeWithText("Upcoming flights").isDisplayed()
+      composeTestRule.onNodeWithText("Upcoming flights").isDisplayed()
     }
     route = navController.currentBackStackEntry?.destination?.route
     Assert.assertEquals(Route.CREW_HOME, route)

--- a/app/src/androidTest/java/ch/epfl/skysync/test_end_to_end/E2EPilotDuringFlight.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/test_end_to_end/E2EPilotDuringFlight.kt
@@ -145,6 +145,8 @@ class E2EPilotDuringFlight {
 
       // Stops the timer by clicking on the "Stop Button"
       composeTestRule.onNodeWithTag("Stop Button").performClick()
+      route = navController.currentBackStackEntry?.destination?.route
+      Assert.assertEquals(Route.CREW_HOME, route)
     }
   }
 }

--- a/app/src/androidTest/java/ch/epfl/skysync/test_end_to_end/E2EPilotDuringFlight.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/test_end_to_end/E2EPilotDuringFlight.kt
@@ -86,8 +86,14 @@ class E2EPilotDuringFlight {
     composeTestRule.onNodeWithText("Flight").performClick()
     var route = navController.currentBackStackEntry?.destination?.route
     Assert.assertEquals(Route.LAUNCH_FLIGHT, route)
-    println("FLIGHTS ${listOf(dbs.flight1.id, dbs.flight2.id, dbs.flight3.id, dbs.flight4.id)}")
     var usedFlightId = ""
+    composeTestRule.waitUntil(3000) {
+      composeTestRule.onNodeWithTag("flightCard${dbs.flight1.id}").isDisplayed() ||
+        composeTestRule.onNodeWithTag("flightCard${dbs.flight2.id}").isDisplayed() ||
+        composeTestRule.onNodeWithTag("flightCard${dbs.flight3.id}").isDisplayed() ||
+        composeTestRule.onNodeWithTag("flightCard${dbs.flight4.id}").isDisplayed()
+
+    }
     for (f in listOf(dbs.flight1, dbs.flight2, dbs.flight3, dbs.flight4)) {
       if (composeTestRule.onNodeWithTag("flightCard${f.id}").isDisplayed()) {
         usedFlightId = f.id
@@ -103,8 +109,9 @@ class E2EPilotDuringFlight {
     composeTestRule.onNodeWithTag("Start Button").performClick()
 
     // Asserts the presence of the map and "Locate Me" button
-    composeTestRule.onNodeWithTag("Map").assertExists()
-    composeTestRule.onNodeWithContentDescription("Locate Me").assertIsDisplayed()
+    composeTestRule.waitUntil(3000){
+            composeTestRule.onNodeWithContentDescription("Locate Me").isDisplayed()
+    }
 
     // Opens flight information and asserts the display of navigation information
     composeTestRule.onNodeWithContentDescription("Flight infos").performClick()
@@ -127,7 +134,7 @@ class E2EPilotDuringFlight {
     composeTestRule.waitForIdle()
 
     // clicks on group chat
-    composeTestRule.waitUntil(2500) {
+    composeTestRule.waitUntil(3000) {
       composeTestRule.onAllNodesWithTag("GroupCard$index").fetchSemanticsNodes().isNotEmpty()
     }
     composeTestRule.onNodeWithTag("GroupCard$index").performClick()
@@ -138,7 +145,9 @@ class E2EPilotDuringFlight {
 
     // Returns to the flight screen with the timer still running
     composeTestRule.onNodeWithText("Flight").performClick()
-    composeTestRule.waitForIdle()
+    composeTestRule.waitUntil(3000) {
+      composeTestRule.onNodeWithTag("Stop Button").isDisplayed()
+    }
     route = navController.currentBackStackEntry?.destination?.route
     Assert.assertEquals(Route.FLIGHT, route)
 
@@ -146,6 +155,9 @@ class E2EPilotDuringFlight {
     composeTestRule.onNodeWithTag("Stop Button").performClick()
     composeTestRule.waitUntil(3000) { composeTestRule.onNodeWithTag("Clear Button").isDisplayed() }
     composeTestRule.onNodeWithTag("Clear Button").performClick()
+    composeTestRule.waitUntil(3000) {
+        composeTestRule.onNodeWithText("Upcoming flights").isDisplayed()
+    }
     route = navController.currentBackStackEntry?.destination?.route
     Assert.assertEquals(Route.CREW_HOME, route)
   }

--- a/app/src/androidTest/java/ch/epfl/skysync/viewmodel/InFlightViewModelTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/viewmodel/InFlightViewModelTest.kt
@@ -9,6 +9,7 @@ import ch.epfl.skysync.Repository
 import ch.epfl.skysync.database.DatabaseSetup
 import ch.epfl.skysync.database.FirestoreDatabase
 import ch.epfl.skysync.models.flight.ConfirmedFlight
+import ch.epfl.skysync.models.flight.FinishedFlight
 import ch.epfl.skysync.models.location.FlightTrace
 import ch.epfl.skysync.models.location.Location
 import ch.epfl.skysync.models.location.LocationPoint
@@ -52,10 +53,13 @@ class InFlightViewModelTest {
   }
 
     @Test
-    fun finishedFlightIsSaved()  = runTest {
+    fun finishedFlightIsSavedOnStop()  = runTest {
         inFlightViewModel.setCurrentFlight(dbs.flight4.id)
         inFlightViewModel.startFlight().join()
         inFlightViewModel.stopFlight().join()
+        val flight = flightTable.get(dbs.flight4.id, onError = { assertNull(it) })
+        assertFalse(flight is ConfirmedFlight)
+        assertTrue(flight is FinishedFlight)
     }
 
   @Test

--- a/app/src/androidTest/java/ch/epfl/skysync/viewmodel/InFlightViewModelTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/viewmodel/InFlightViewModelTest.kt
@@ -52,15 +52,15 @@ class InFlightViewModelTest {
     assertTrue(countString == "00:00:00")
   }
 
-    @Test
-    fun finishedFlightIsSavedOnStop()  = runTest {
-        inFlightViewModel.setCurrentFlight(dbs.flight4.id)
-        inFlightViewModel.startFlight().join()
-        inFlightViewModel.stopFlight().join()
-        val flight = flightTable.get(dbs.flight4.id, onError = { assertNull(it) })
-        assertFalse(flight is ConfirmedFlight)
-        assertTrue(flight is FinishedFlight)
-    }
+  @Test
+  fun finishedFlightIsSavedOnStop() = runTest {
+    inFlightViewModel.setCurrentFlight(dbs.flight4.id)
+    inFlightViewModel.startFlight().join()
+    inFlightViewModel.stopFlight().join()
+    val flight = flightTable.get(dbs.flight4.id, onError = { assertNull(it) })
+    assertFalse(flight is ConfirmedFlight)
+    assertTrue(flight is FinishedFlight)
+  }
 
   @Test
   fun testStartFunction() = runTest {

--- a/app/src/androidTest/java/ch/epfl/skysync/viewmodel/InFlightViewModelTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/viewmodel/InFlightViewModelTest.kt
@@ -51,6 +51,13 @@ class InFlightViewModelTest {
     assertTrue(countString == "00:00:00")
   }
 
+    @Test
+    fun finishedFlightIsSaved()  = runTest {
+        inFlightViewModel.setCurrentFlight(dbs.flight4.id)
+        inFlightViewModel.startFlight().join()
+        inFlightViewModel.stopFlight().join()
+    }
+
   @Test
   fun testStartFunction() = runTest {
     inFlightViewModel.setCurrentFlight(dbs.flight4.id)

--- a/app/src/main/java/ch/epfl/skysync/components/Timer.kt
+++ b/app/src/main/java/ch/epfl/skysync/components/Timer.kt
@@ -68,7 +68,7 @@ fun Timer(
                 }
             FlightStage.POST ->
                 Button(modifier = Modifier.testTag("Clear Button"), onClick = { onClear() }) {
-                  Text(text = "Clear Flight")
+                  Text(text = "Exit Flight")
                 }
             FlightStage.DISPLAY ->
                 Button(modifier = Modifier.testTag("Quit Button"), onClick = { onQuitDisplay() }) {

--- a/app/src/main/java/ch/epfl/skysync/database/DateUtility.kt
+++ b/app/src/main/java/ch/epfl/skysync/database/DateUtility.kt
@@ -40,7 +40,8 @@ object DateUtility {
    * @return The equivalent [LocalDate] object.
    */
   fun dateToLocalDate(date: Long): LocalDate {
-    return Instant.ofEpochMilli(date).atZone(ZoneId.of("GMT")).toLocalDate()
+
+    return Instant.ofEpochMilli(date).atZone(ZoneId.systemDefault()).toLocalDate()
   }
   /**
    * Converts a [LocalDate] object to a [Date] object.
@@ -49,7 +50,7 @@ object DateUtility {
    * @return The equivalent [Date] object.
    */
   fun localDateToDate(localDate: LocalDate): Date {
-    return Date.from(localDate.atStartOfDay(ZoneOffset.UTC).toInstant())
+    return Date.from(localDate.atStartOfDay(ZoneOffset.systemDefault()).toInstant())
   }
 
   /**
@@ -116,7 +117,7 @@ object DateUtility {
     val formatter = DateTimeFormatter.ofPattern("HH:mm")
     val localTime = LocalTime.parse(time, formatter)
     val localDateTime = LocalDateTime.of(date, localTime)
-    return Date.from(localDateTime.atZone(ZoneOffset.UTC).toInstant())
+    return Date.from(localDateTime.atZone(ZoneOffset.systemDefault()).toInstant())
   }
 
   /** Formats the given time in milliseconds to a string in the format "HH:MM:SS". */

--- a/app/src/main/java/ch/epfl/skysync/database/tables/FlightTable.kt
+++ b/app/src/main/java/ch/epfl/skysync/database/tables/FlightTable.kt
@@ -20,7 +20,6 @@ import ch.epfl.skysync.models.flight.Vehicle
 import ch.epfl.skysync.models.location.FlightTrace
 import ch.epfl.skysync.models.location.LocationPoint
 import ch.epfl.skysync.models.reports.Report
-import ch.epfl.skysync.models.reports.FlightReport
 import ch.epfl.skysync.models.user.User
 import com.google.firebase.firestore.FieldPath
 import com.google.firebase.firestore.Filter
@@ -280,8 +279,7 @@ class FlightTable(db: FirestoreDatabase) :
         vehicles = vehicles!!,
         team = team!!,
         reports = reports,
-        flightTrace = FlightTrace(flightSchema.id!!, emptyList())
-    )
+        flightTrace = FlightTrace(flightSchema.id!!, emptyList()))
   }
 
   override suspend fun get(id: String, onError: ((Exception) -> Unit)?): Flight? {
@@ -366,12 +364,11 @@ class FlightTable(db: FirestoreDatabase) :
           listOf(
                   launch { db.setItem(path, id, FlightSchema.fromModel(item)) },
                   launch { setTeam(id, item.team) },
-                    launch {
-                        if (item is FinishedFlight && item.reportId.isNotEmpty()) {
-                            reportTable.addAll(item.reportId, id)
-                        }
+                  launch {
+                    if (item is FinishedFlight && item.reportId.isNotEmpty()) {
+                      reportTable.addAll(item.reportId, id)
                     }
-          )
+                  })
               .forEach { it.join() }
         }
       }

--- a/app/src/main/java/ch/epfl/skysync/database/tables/FlightTable.kt
+++ b/app/src/main/java/ch/epfl/skysync/database/tables/FlightTable.kt
@@ -345,7 +345,7 @@ class FlightTable(db: FirestoreDatabase) :
       val flightId = db.addItem(path, FlightSchema.fromModel(item))
       addTeam(flightId, item.team)
       if (item is FinishedFlight && item.reportId.isNotEmpty()) {
-        reportTable.addAll(item.reportId as List<FlightReport>, flightId)
+        reportTable.addAll(item.reportId, flightId)
       }
       flightId
     }

--- a/app/src/main/java/ch/epfl/skysync/database/tables/FlightTable.kt
+++ b/app/src/main/java/ch/epfl/skysync/database/tables/FlightTable.kt
@@ -53,7 +53,7 @@ class FlightTable(db: FirestoreDatabase) :
       vehicles: List<Vehicle>,
       team: Team,
       flightTrace: FlightTrace?,
-      reports: List<Report> = emptyList(),
+      reports: List<Report>? = emptyList(),
   ): Flight {
     return when (schema.status!!) {
       FlightStatus.PLANNED ->
@@ -117,7 +117,7 @@ class FlightTable(db: FirestoreDatabase) :
                   LocationPoint(
                       0, schema.landingLocationLat!!, schema.landingLocationLong!!, "LandingSpot"),
               flightTime = schema.flightTime!!,
-              reportId = reports,
+              reportId = reports!!,
               flightTrace = flightTrace!!)
     }
   }
@@ -279,6 +279,7 @@ class FlightTable(db: FirestoreDatabase) :
         basket = basket,
         vehicles = vehicles!!,
         team = team!!,
+        reports = reports,
         flightTrace = FlightTrace(flightSchema.id!!, emptyList())
     )
   }

--- a/app/src/main/java/ch/epfl/skysync/database/tables/FlightTable.kt
+++ b/app/src/main/java/ch/epfl/skysync/database/tables/FlightTable.kt
@@ -19,6 +19,7 @@ import ch.epfl.skysync.models.flight.Team
 import ch.epfl.skysync.models.flight.Vehicle
 import ch.epfl.skysync.models.location.FlightTrace
 import ch.epfl.skysync.models.location.LocationPoint
+import ch.epfl.skysync.models.reports.Report
 import ch.epfl.skysync.models.user.User
 import com.google.firebase.firestore.FieldPath
 import com.google.firebase.firestore.Filter
@@ -49,7 +50,8 @@ class FlightTable(db: FirestoreDatabase) :
       basket: Basket?,
       vehicles: List<Vehicle>,
       team: Team,
-      flightTrace: FlightTrace?
+      flightTrace: FlightTrace?,
+      reports: List<Report> = emptyList(),
   ): Flight {
     return when (schema.status!!) {
       FlightStatus.PLANNED ->
@@ -113,7 +115,7 @@ class FlightTable(db: FirestoreDatabase) :
                   LocationPoint(
                       0, schema.landingLocationLat!!, schema.landingLocationLong!!, "LandingSpot"),
               flightTime = schema.flightTime!!,
-              reportId = listOf(), // Todo: retrieve reports
+              reportId = reports,
               flightTrace = flightTrace!!)
     }
   }
@@ -264,13 +266,14 @@ class FlightTable(db: FirestoreDatabase) :
             launch { team = retrieveTeam(flightSchema) })
     jobs.forEach { it.join() }
     makeFlight(
-        flightSchema,
-        flightType!!,
-        balloon,
-        basket,
-        vehicles!!,
-        team!!,
-        FlightTrace(flightSchema.id!!, emptyList()))
+        schema = flightSchema,
+        flightType = flightType!!,
+        balloon = balloon,
+        basket = basket,
+        vehicles = vehicles!!,
+        team = team!!,
+        flightTrace = FlightTrace(flightSchema.id!!, emptyList())
+    )
   }
 
   override suspend fun get(id: String, onError: ((Exception) -> Unit)?): Flight? {

--- a/app/src/main/java/ch/epfl/skysync/database/tables/FlightTable.kt
+++ b/app/src/main/java/ch/epfl/skysync/database/tables/FlightTable.kt
@@ -365,7 +365,13 @@ class FlightTable(db: FirestoreDatabase) :
         withErrorCallback(onError) {
           listOf(
                   launch { db.setItem(path, id, FlightSchema.fromModel(item)) },
-                  launch { setTeam(id, item.team) })
+                  launch { setTeam(id, item.team) },
+                    launch {
+                        if (item is FinishedFlight && item.reportId.isNotEmpty()) {
+                            reportTable.addAll(item.reportId, id)
+                        }
+                    }
+          )
               .forEach { it.join() }
         }
       }

--- a/app/src/main/java/ch/epfl/skysync/models/location/LocationPoint.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/location/LocationPoint.kt
@@ -11,9 +11,7 @@ data class LocationPoint(
 ) {
   fun latlng(): LatLng = LatLng(latitude, longitude)
 
-    companion object {
-        val UNKNONWN_POINT = LocationPoint(-1, 0.0, 0.0)
-    }
+  companion object {
+    val UNKNONWN_POINT = LocationPoint(-1, 0.0, 0.0)
+  }
 }
-
-

--- a/app/src/main/java/ch/epfl/skysync/models/location/LocationPoint.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/location/LocationPoint.kt
@@ -10,4 +10,10 @@ data class LocationPoint(
     val name: String = ""
 ) {
   fun latlng(): LatLng = LatLng(latitude, longitude)
+
+    companion object {
+        val UNKNONWN_POINT = LocationPoint(-1, 0.0, 0.0)
+    }
 }
+
+

--- a/app/src/main/java/ch/epfl/skysync/screens/crewpilot/Flight.kt
+++ b/app/src/main/java/ch/epfl/skysync/screens/crewpilot/Flight.kt
@@ -161,9 +161,9 @@ fun FlightScreen(
                       onStart = { inFlightViewModel.startFlight() },
                       onStop = { inFlightViewModel.stopFlight() },
                       onClear = {
-                          inFlightViewModel.clearFlight()
-                          navController.navigate(Route.CREW_HOME)
-                                },
+                        inFlightViewModel.clearFlight()
+                        navController.navigate(Route.CREW_HOME)
+                      },
                       onQuitDisplay = {
                         inFlightViewModel.quitDisplayFlightTrace()
                         navController.popBackStack()

--- a/app/src/main/java/ch/epfl/skysync/screens/crewpilot/Flight.kt
+++ b/app/src/main/java/ch/epfl/skysync/screens/crewpilot/Flight.kt
@@ -38,6 +38,7 @@ import ch.epfl.skysync.models.location.LocationPoint
 import ch.epfl.skysync.models.location.UserMetrics
 import ch.epfl.skysync.models.user.User
 import ch.epfl.skysync.navigation.BottomBar
+import ch.epfl.skysync.navigation.Route
 import ch.epfl.skysync.ui.theme.lightOrange
 import ch.epfl.skysync.viewmodel.InFlightViewModel
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
@@ -159,7 +160,10 @@ fun FlightScreen(
                       isPilot = inFlightViewModel.isPilot(),
                       onStart = { inFlightViewModel.startFlight() },
                       onStop = { inFlightViewModel.stopFlight() },
-                      onClear = { inFlightViewModel.clearFlight() },
+                      onClear = {
+                          inFlightViewModel.clearFlight()
+                          navController.navigate(Route.CREW_HOME)
+                                },
                       onQuitDisplay = {
                         inFlightViewModel.quitDisplayFlightTrace()
                         navController.popBackStack()

--- a/app/src/main/java/ch/epfl/skysync/viewmodel/InFlightViewModel.kt
+++ b/app/src/main/java/ch/epfl/skysync/viewmodel/InFlightViewModel.kt
@@ -372,9 +372,16 @@ class InFlightViewModel(val repository: Repository) : ViewModel() {
 
   /** Save the finished flight to the database */
   private suspend fun saveFinishedFlight() {
-    if (currentFlight.value == null) {
-      return
-    }
+    val flightToSave = _currentFlight.value ?: return
+    val finishedFlight = flightToSave.finishFlight(
+        takeOffTime = takeOffTime!!,
+        landingTime = landingTime!!,
+        flightTime = _counter.value,
+        takeOffLocation = _flightLocations.value.first().point,
+        landingLocation = _flightLocations.value.last().point,
+        flightTrace = FlightTrace(trace = _flightLocations.value.map { it.point })
+    )
+    flightTable.update(finishedFlight.id, finishedFlight, onError = { onError(it) })
     Log.d("InFlightViewModel", "Saving finished flight")
   }
 

--- a/app/src/main/java/ch/epfl/skysync/viewmodel/InFlightViewModel.kt
+++ b/app/src/main/java/ch/epfl/skysync/viewmodel/InFlightViewModel.kt
@@ -18,6 +18,7 @@ import ch.epfl.skysync.models.flight.RoleType
 import ch.epfl.skysync.models.flight.Team
 import ch.epfl.skysync.models.location.FlightTrace
 import ch.epfl.skysync.models.location.Location
+import ch.epfl.skysync.models.location.LocationPoint
 import ch.epfl.skysync.models.user.User
 import ch.epfl.skysync.util.WhileUiSubscribed
 import com.google.firebase.firestore.Filter
@@ -372,13 +373,14 @@ class InFlightViewModel(val repository: Repository) : ViewModel() {
 
   /** Save the finished flight to the database */
   private suspend fun saveFinishedFlight() {
+
     val flightToSave = _currentFlight.value ?: return
     val finishedFlight = flightToSave.finishFlight(
         takeOffTime = takeOffTime!!,
         landingTime = landingTime!!,
         flightTime = _counter.value,
-        takeOffLocation = _flightLocations.value.first().point,
-        landingLocation = _flightLocations.value.last().point,
+        takeOffLocation = _flightLocations.value.firstOrNull()?.point?: LocationPoint.UNKNONWN_POINT,
+        landingLocation = _flightLocations.value.lastOrNull()?.point?: LocationPoint.UNKNONWN_POINT,
         flightTrace = FlightTrace(trace = _flightLocations.value.map { it.point })
     )
     flightTable.update(finishedFlight.id, finishedFlight, onError = { onError(it) })

--- a/app/src/main/java/ch/epfl/skysync/viewmodel/InFlightViewModel.kt
+++ b/app/src/main/java/ch/epfl/skysync/viewmodel/InFlightViewModel.kt
@@ -413,14 +413,16 @@ class InFlightViewModel(val repository: Repository) : ViewModel() {
   private suspend fun saveFinishedFlight() {
 
     val flightToSave = _currentFlight.value ?: return
-    val finishedFlight = flightToSave.finishFlight(
-        takeOffTime = takeOffTime!!,
-        landingTime = landingTime!!,
-        flightTime = _counter.value,
-        takeOffLocation = _flightLocations.value.firstOrNull()?.point?: LocationPoint.UNKNONWN_POINT,
-        landingLocation = _flightLocations.value.lastOrNull()?.point?: LocationPoint.UNKNONWN_POINT,
-        flightTrace = FlightTrace(trace = _flightLocations.value.map { it.point })
-    )
+    val finishedFlight =
+        flightToSave.finishFlight(
+            takeOffTime = takeOffTime!!,
+            landingTime = landingTime!!,
+            flightTime = _counter.value,
+            takeOffLocation =
+                _flightLocations.value.firstOrNull()?.point ?: LocationPoint.UNKNONWN_POINT,
+            landingLocation =
+                _flightLocations.value.lastOrNull()?.point ?: LocationPoint.UNKNONWN_POINT,
+            flightTrace = FlightTrace(trace = _flightLocations.value.map { it.point }))
     flightTable.update(finishedFlight.id, finishedFlight, onError = { onError(it) })
     Log.d("InFlightViewModel", "Saving finished flight")
   }


### PR DESCRIPTION
closes #356 
# VM integration
- on stoping an ongoing flight the underlying `ConfirmedFlight` is transformed into a `FinishedFlight` and saved to the DB
- the finished flight is properly displayed in the overview screen
<img width="326" alt="Screenshot 2024-05-22 at 17 47 25" src="https://github.com/SkySync-EPFL/skysync/assets/37707941/29a66959-30b8-45a3-a96b-9773c51673c8">

- corrected timezones to systemdefault for all DateUtils functions
# in-flight clear button
- changed name of in-flight clear button to exit
- added navigation to HomeScreen to onClick behaviour of in-flight clear button: 

