### PR TITLE
Filter finished flights

### DIFF
--- a/app/src/main/java/ch/epfl/skysync/models/flight/FinishedFlight.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/flight/FinishedFlight.kt
@@ -29,11 +29,11 @@ data class FinishedFlight(
     val flightTime: Long, // time in milliseconds
     val reportId: List<Report> = emptyList(),
     val flightTrace: FlightTrace = FlightTrace(UNSET_ID, emptyList()),
-    val flightStatus: FlightStatus = FlightStatus.MISSING_REPORT,
+    private val thisFlightStatus: FlightStatus = FlightStatus.MISSING_REPORT,
 ) : Flight {
 
   override fun getFlightStatus(): FlightStatus {
-    return flightStatus
+    return thisFlightStatus
   }
 
     /**
@@ -56,12 +56,12 @@ data class FinishedFlight(
      */
     private fun updateFlightStatusForWithCondition(flightIsCompleted: () -> Boolean): FinishedFlight {
         if (flightIsCompleted()) {
-            if (flightStatus == FlightStatus.MISSING_REPORT) {
-                return copy(flightStatus = FlightStatus.COMPLETED)
+            if (thisFlightStatus == FlightStatus.MISSING_REPORT) {
+                return copy(thisFlightStatus = FlightStatus.COMPLETED)
             }
         } else {
-            if (flightStatus == FlightStatus.COMPLETED) {
-                return copy(flightStatus = FlightStatus.MISSING_REPORT)
+            if (thisFlightStatus == FlightStatus.COMPLETED) {
+                return copy(thisFlightStatus = FlightStatus.MISSING_REPORT)
             }
         }
         return this

--- a/app/src/main/java/ch/epfl/skysync/models/flight/FinishedFlight.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/flight/FinishedFlight.kt
@@ -5,6 +5,8 @@ import ch.epfl.skysync.models.calendar.TimeSlot
 import ch.epfl.skysync.models.location.FlightTrace
 import ch.epfl.skysync.models.location.LocationPoint
 import ch.epfl.skysync.models.reports.Report
+import ch.epfl.skysync.models.user.Admin
+import ch.epfl.skysync.models.user.User
 import java.time.LocalDate
 import java.util.Date
 
@@ -26,16 +28,57 @@ data class FinishedFlight(
     val landingLocation: LocationPoint,
     val flightTime: Long, // time in milliseconds
     val reportId: List<Report> = emptyList(),
-    val flightTrace: FlightTrace = FlightTrace(UNSET_ID, emptyList())
+    val flightTrace: FlightTrace = FlightTrace(UNSET_ID, emptyList()),
+    val flightStatus: FlightStatus = FlightStatus.MISSING_REPORT,
 ) : Flight {
 
-  private var flightStatus = FlightStatus.MISSING_REPORT
-
   override fun getFlightStatus(): FlightStatus {
-    return this.flightStatus
+    return flightStatus
   }
 
-  fun reportCompleted() {
-    this.flightStatus = FlightStatus.COMPLETED
-  }
+    /**
+     * Update the flight status based on the reports submitted
+     * For an ADMIN a flight is considered completed iff all the team members have submitted
+     * their report.
+     * For an CREW/PILOT the flight is considered completed iff the user has submitted their own report
+     *
+     */
+    fun updateFlightStatus(user: User): FinishedFlight {
+        return if (user is Admin) {
+            updateFlightStatusForAdmin()
+        } else{
+            updateFlightStatusForCrewPilot(user)
+        }
+    }
+
+    /**
+     * Update the flight status based on the flightIsCompleted condition
+     */
+    private fun updateFlightStatusForWithCondition(flightIsCompleted: () -> Boolean): FinishedFlight {
+        if (flightIsCompleted()) {
+            if (flightStatus == FlightStatus.MISSING_REPORT) {
+                return copy(flightStatus = FlightStatus.COMPLETED)
+            }
+        } else {
+            if (flightStatus == FlightStatus.COMPLETED) {
+                return copy(flightStatus = FlightStatus.MISSING_REPORT)
+            }
+        }
+        return this
+    }
+
+    /**
+     * For an CREW/PILOT the flight is considered completed iff the user has submitted their own report
+     */
+    private fun updateFlightStatusForCrewPilot(user: User): FinishedFlight {
+        return updateFlightStatusForWithCondition { reportId.any {it.authoredBy(user)} }
+    }
+
+    /**
+     * For an ADMIN a flight is considered completed iff all the team members have submitted
+     * their report.
+     */
+    private fun updateFlightStatusForAdmin(): FinishedFlight {
+        return updateFlightStatusForWithCondition { reportId.size == team.size() }
+    }
 }

--- a/app/src/main/java/ch/epfl/skysync/models/flight/Team.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/flight/Team.kt
@@ -18,6 +18,13 @@ data class Team(val roles: List<Role>) {
     return roles.isNotEmpty() && roles.all { it.isAssigned() }
   }
 
+  /**
+   * @return the number of roles in the team
+   */
+  fun size(): Int {
+    return roles.size
+  }
+
   fun getUsers(): List<User> {
     return roles.mapNotNull { it.assignedUser }
   }

--- a/app/src/main/java/ch/epfl/skysync/models/reports/Report.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/reports/Report.kt
@@ -1,5 +1,6 @@
 package ch.epfl.skysync.models.reports
 
+import ch.epfl.skysync.models.user.User
 import java.util.Date
 
 interface Report {
@@ -9,4 +10,12 @@ interface Report {
   val end: Date
   val pauseDuration: Int // in milliseconds
   val comments: String
+
+  /**
+   * @param user the user to check if the report was authored by
+   * @return true if this report was authored by the given user
+   */
+  fun authoredBy(user: User): Boolean {
+    return author == user.id
+  }
 }

--- a/app/src/main/java/ch/epfl/skysync/viewmodel/FlightsViewModel.kt
+++ b/app/src/main/java/ch/epfl/skysync/viewmodel/FlightsViewModel.kt
@@ -13,6 +13,7 @@ import ch.epfl.skysync.models.calendar.TimeSlot
 import ch.epfl.skysync.models.flight.Balloon
 import ch.epfl.skysync.models.flight.Basket
 import ch.epfl.skysync.models.flight.ConfirmedFlight
+import ch.epfl.skysync.models.flight.FinishedFlight
 import ch.epfl.skysync.models.flight.Flight
 import ch.epfl.skysync.models.flight.FlightType
 import ch.epfl.skysync.models.flight.PlannedFlight
@@ -106,9 +107,16 @@ class FlightsViewModel(
           Log.d("FlightsViewModel", "Admin user loaded")
           _currentFlights.value = repository.flightTable.getAll(onError = { onError(it) })
         } else if (_currentUser.value is Pilot || _currentUser.value is Crew) {
-          _currentFlights.value =
+          val fetchedFlights =
               repository.userTable.retrieveAssignedFlights(
                   repository.flightTable, userId ?: UNSET_ID, onError = { onError(it) })
+            _currentFlights.value = fetchedFlights.map {
+                if (it is FinishedFlight) {
+                    it.updateFlightStatus(_currentUser.value!!)
+                } else {
+                    it
+                }
+            }
           Log.d("FlightsViewModel", "Pilot or Crew user loaded")
         }
       }


### PR DESCRIPTION
# filter `FinishedFlight` for `COMPLETED` and `MISSING_REPORT`
- added function to update the `FlightStatus` of a `FinishedFlight` as a function of a user
For an `Admin` a `FinishedFlight` is considered `COMPLETED` once all team members have submitted their `Report`
For a `Crew/Pilot `it requires only the submission of the personal `Report` to have a `COMPLETED` finished flight
- 