### PR TITLE
Filter finished flights

### DIFF
--- a/app/src/androidTest/java/ch/epfl/skysync/viewmodel/FlightsViewModelTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/viewmodel/FlightsViewModelTest.kt
@@ -186,7 +186,7 @@ class FlightsViewModelTest {
     runTest {
       viewModelAdmin.refreshUserAndFlights().join()
       val currentFlights = viewModelAdmin.currentFlights.value
-      assertEquals(4, currentFlights?.size)
+      assertEquals(5, currentFlights?.size)
     }
   }
 
@@ -314,7 +314,7 @@ class FlightsViewModelTest {
               id = flightTable.add(flightWithoutCrew, onError = { assertNull(it) }))
 
       viewModelAdmin.refreshUserAndFlights().join()
-      assertEquals(6, viewModelAdmin.currentFlights.value?.size)
+      assertEquals(7, viewModelAdmin.currentFlights.value?.size)
     }
   }
 
@@ -325,7 +325,7 @@ class FlightsViewModelTest {
     }
 
     runTest {
-      var flight1 =
+      val flight1 =
           PlannedFlight(
               nPassengers = 2,
               team =
@@ -346,7 +346,7 @@ class FlightsViewModelTest {
 
       viewModelAdmin.refreshUserAndFlights().join()
 
-      assertEquals(5, viewModelAdmin.currentFlights.value?.size)
+      assertEquals(6, viewModelAdmin.currentFlights.value?.size)
     }
   }
 
@@ -392,7 +392,7 @@ class FlightsViewModelTest {
               id = UNSET_ID)
       viewModelAdmin.refreshUserAndFlights().join()
       val initFlights = viewModelAdmin.currentFlights.value
-      assertEquals(4, initFlights?.size)
+      assertEquals(5, initFlights?.size)
 
       flight1 = flight1.copy(id = flightTable.add(flight1, onError = { assertNull(it) }))
 
@@ -455,7 +455,7 @@ class FlightsViewModelTest {
 
       viewModelAdmin.refreshUserAndFlights().join()
 
-      assertEquals(5, viewModelAdmin.currentFlights.value?.size)
+      assertEquals(6, viewModelAdmin.currentFlights.value?.size)
       assertTrue(viewModelAdmin.currentFlights.value?.contains(modifiedFlight) ?: false)
     }
   }

--- a/app/src/androidTest/java/ch/epfl/skysync/viewmodel/FlightsViewModelTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/viewmodel/FlightsViewModelTest.kt
@@ -401,7 +401,7 @@ class FlightsViewModelTest {
       viewModelAdmin.refreshUserAndFlights().join()
       val withFlightsAdded = viewModelAdmin.currentFlights.value
 
-      assertEquals(6, withFlightsAdded?.size)
+      assertEquals(7, withFlightsAdded?.size)
 
       viewModelAdmin.deleteFlight(flight1.id).join()
 
@@ -409,9 +409,7 @@ class FlightsViewModelTest {
 
       val withOneFlightDeleted = viewModelAdmin.currentFlights.value
 
-      var flight2StillAvailable = false
-
-      assertEquals(5, withOneFlightDeleted?.size)
+      assertEquals(6, withOneFlightDeleted?.size)
       assertTrue(withOneFlightDeleted?.contains(flight2) ?: false)
       assertFalse(withOneFlightDeleted?.contains(flight1) ?: true)
     }

--- a/app/src/main/java/ch/epfl/skysync/models/flight/FinishedFlight.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/flight/FinishedFlight.kt
@@ -29,11 +29,11 @@ data class FinishedFlight(
     val flightTime: Long, // time in milliseconds
     val reportId: List<Report> = emptyList(),
     val flightTrace: FlightTrace = FlightTrace(UNSET_ID, emptyList()),
-    val flightStatus: FlightStatus = FlightStatus.MISSING_REPORT,
+    private val thisFlightStatus: FlightStatus = FlightStatus.MISSING_REPORT,
 ) : Flight {
 
   override fun getFlightStatus(): FlightStatus {
-    return flightStatus
+    return thisFlightStatus
   }
 
     /**
@@ -56,12 +56,12 @@ data class FinishedFlight(
      */
     private fun updateFlightStatusForWithCondition(flightIsCompleted: () -> Boolean): FinishedFlight {
         if (flightIsCompleted()) {
-            if (flightStatus == FlightStatus.MISSING_REPORT) {
-                return copy(flightStatus = FlightStatus.COMPLETED)
+            if (thisFlightStatus == FlightStatus.MISSING_REPORT) {
+                return copy(thisFlightStatus = FlightStatus.COMPLETED)
             }
         } else {
-            if (flightStatus == FlightStatus.COMPLETED) {
-                return copy(flightStatus = FlightStatus.MISSING_REPORT)
+            if (thisFlightStatus == FlightStatus.COMPLETED) {
+                return copy(thisFlightStatus = FlightStatus.MISSING_REPORT)
             }
         }
         return this

--- a/app/src/main/java/ch/epfl/skysync/models/flight/FinishedFlight.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/flight/FinishedFlight.kt
@@ -5,6 +5,8 @@ import ch.epfl.skysync.models.calendar.TimeSlot
 import ch.epfl.skysync.models.location.FlightTrace
 import ch.epfl.skysync.models.location.LocationPoint
 import ch.epfl.skysync.models.reports.Report
+import ch.epfl.skysync.models.user.Admin
+import ch.epfl.skysync.models.user.User
 import java.time.LocalDate
 import java.util.Date
 
@@ -26,16 +28,57 @@ data class FinishedFlight(
     val landingLocation: LocationPoint,
     val flightTime: Long, // time in milliseconds
     val reportId: List<Report> = emptyList(),
-    val flightTrace: FlightTrace = FlightTrace(UNSET_ID, emptyList())
+    val flightTrace: FlightTrace = FlightTrace(UNSET_ID, emptyList()),
+    val flightStatus: FlightStatus = FlightStatus.MISSING_REPORT,
 ) : Flight {
 
-  private var flightStatus = FlightStatus.MISSING_REPORT
-
   override fun getFlightStatus(): FlightStatus {
-    return this.flightStatus
+    return flightStatus
   }
 
-  fun reportCompleted() {
-    this.flightStatus = FlightStatus.COMPLETED
-  }
+    /**
+     * Update the flight status based on the reports submitted
+     * For an ADMIN a flight is considered completed iff all the team members have submitted
+     * their report.
+     * For an CREW/PILOT the flight is considered completed iff the user has submitted their own report
+     *
+     */
+    fun updateFlightStatus(user: User): FinishedFlight {
+        return if (user is Admin) {
+            updateFlightStatusForAdmin()
+        } else{
+            updateFlightStatusForCrewPilot(user)
+        }
+    }
+
+    /**
+     * Update the flight status based on the flightIsCompleted condition
+     */
+    private fun updateFlightStatusForWithCondition(flightIsCompleted: () -> Boolean): FinishedFlight {
+        if (flightIsCompleted()) {
+            if (flightStatus == FlightStatus.MISSING_REPORT) {
+                return copy(flightStatus = FlightStatus.COMPLETED)
+            }
+        } else {
+            if (flightStatus == FlightStatus.COMPLETED) {
+                return copy(flightStatus = FlightStatus.MISSING_REPORT)
+            }
+        }
+        return this
+    }
+
+    /**
+     * For an CREW/PILOT the flight is considered completed iff the user has submitted their own report
+     */
+    private fun updateFlightStatusForCrewPilot(user: User): FinishedFlight {
+        return updateFlightStatusForWithCondition { reportId.any {it.authoredBy(user)} }
+    }
+
+    /**
+     * For an ADMIN a flight is considered completed iff all the team members have submitted
+     * their report.
+     */
+    private fun updateFlightStatusForAdmin(): FinishedFlight {
+        return updateFlightStatusForWithCondition { reportId.size == team.size() }
+    }
 }

--- a/app/src/main/java/ch/epfl/skysync/models/flight/FinishedFlight.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/flight/FinishedFlight.kt
@@ -77,24 +77,8 @@ data class FinishedFlight(
    */
   private fun updateFlightStatusForAdmin(): FinishedFlight {
     return updateFlightStatusForWithCondition {
-      val nReports = reportId.size
-      val teamSize = team.size()
-      val allReportsCompleted = nReports == teamSize
+      val allReportsCompleted = reportId.size == team.size()
       allReportsCompleted
-    }
-  }
-
-  companion object {
-    fun filterCompletedFlights(flights: List<Flight>, user: User): List<Flight> {
-      return flights
-          .map {
-            if (it is FinishedFlight) {
-              it.updateFlightStatus(user)
-            } else {
-              it
-            }
-          }
-          .filter { it.getFlightStatus() != FlightStatus.COMPLETED }
     }
   }
 }

--- a/app/src/main/java/ch/epfl/skysync/models/flight/FinishedFlight.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/flight/FinishedFlight.kt
@@ -36,49 +36,65 @@ data class FinishedFlight(
     return thisFlightStatus
   }
 
-    /**
-     * Update the flight status based on the reports submitted
-     * For an ADMIN a flight is considered completed iff all the team members have submitted
-     * their report.
-     * For an CREW/PILOT the flight is considered completed iff the user has submitted their own report
-     *
-     */
-    fun updateFlightStatus(user: User): FinishedFlight {
-        return if (user is Admin) {
-            updateFlightStatusForAdmin()
-        } else{
-            updateFlightStatusForCrewPilot(user)
-        }
+  /**
+   * Update the flight status based on the reports submitted For an ADMIN a flight is considered
+   * completed iff all the team members have submitted their report. For an CREW/PILOT the flight is
+   * considered completed iff the user has submitted their own report
+   */
+  fun updateFlightStatus(user: User): FinishedFlight {
+    return if (user is Admin) {
+      updateFlightStatusForAdmin()
+    } else {
+      updateFlightStatusForCrewPilot(user)
     }
+  }
 
-    /**
-     * Update the flight status based on the flightIsCompleted condition
-     */
-    private fun updateFlightStatusForWithCondition(flightIsCompleted: () -> Boolean): FinishedFlight {
-        if (flightIsCompleted()) {
-            if (thisFlightStatus == FlightStatus.MISSING_REPORT) {
-                return copy(thisFlightStatus = FlightStatus.COMPLETED)
+  /** Update the flight status based on the flightIsCompleted condition */
+  private fun updateFlightStatusForWithCondition(flightIsCompleted: () -> Boolean): FinishedFlight {
+    if (flightIsCompleted()) {
+      if (thisFlightStatus == FlightStatus.MISSING_REPORT) {
+        return copy(thisFlightStatus = FlightStatus.COMPLETED)
+      }
+    } else {
+      if (thisFlightStatus == FlightStatus.COMPLETED) {
+        return copy(thisFlightStatus = FlightStatus.MISSING_REPORT)
+      }
+    }
+    return this
+  }
+
+  /**
+   * For an CREW/PILOT the flight is considered completed iff the user has submitted their own
+   * report
+   */
+  private fun updateFlightStatusForCrewPilot(user: User): FinishedFlight {
+    return updateFlightStatusForWithCondition { reportId.any { it.authoredBy(user) } }
+  }
+
+  /**
+   * For an ADMIN a flight is considered completed iff all the team members have submitted their
+   * report.
+   */
+  private fun updateFlightStatusForAdmin(): FinishedFlight {
+    return updateFlightStatusForWithCondition {
+      val nReports = reportId.size
+      val teamSize = team.size()
+      val allReportsCompleted = nReports == teamSize
+      allReportsCompleted
+    }
+  }
+
+  companion object {
+    fun filterCompletedFlights(flights: List<Flight>, user: User): List<Flight> {
+      return flights
+          .map {
+            if (it is FinishedFlight) {
+              it.updateFlightStatus(user)
+            } else {
+              it
             }
-        } else {
-            if (thisFlightStatus == FlightStatus.COMPLETED) {
-                return copy(thisFlightStatus = FlightStatus.MISSING_REPORT)
-            }
-        }
-        return this
+          }
+          .filter { it.getFlightStatus() != FlightStatus.COMPLETED }
     }
-
-    /**
-     * For an CREW/PILOT the flight is considered completed iff the user has submitted their own report
-     */
-    private fun updateFlightStatusForCrewPilot(user: User): FinishedFlight {
-        return updateFlightStatusForWithCondition { reportId.any {it.authoredBy(user)} }
-    }
-
-    /**
-     * For an ADMIN a flight is considered completed iff all the team members have submitted
-     * their report.
-     */
-    private fun updateFlightStatusForAdmin(): FinishedFlight {
-        return updateFlightStatusForWithCondition { reportId.size == team.size() }
-    }
+  }
 }

--- a/app/src/main/java/ch/epfl/skysync/models/flight/FlightStatus.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/flight/FlightStatus.kt
@@ -19,20 +19,19 @@ enum class FlightStatus(val text: String, val displayColor: Color) {
   override fun toString(): String {
     return text
   }
+
   companion object {
-    /**
-     * updates the status of all FinishedFlights and Filters out the flights that are completed
-     */
+    /** updates the status of all FinishedFlights and Filters out the flights that are completed */
     fun filterCompletedFlights(flights: List<Flight>, user: User): List<Flight> {
       return flights
-        .map {
-          if (it is FinishedFlight) {
-            it.updateFlightStatus(user)
-          } else {
-            it
+          .map {
+            if (it is FinishedFlight) {
+              it.updateFlightStatus(user)
+            } else {
+              it
+            }
           }
-        }
-        .filter { it.getFlightStatus() != COMPLETED }
+          .filter { it.getFlightStatus() != COMPLETED }
     }
   }
 }

--- a/app/src/main/java/ch/epfl/skysync/models/flight/FlightStatus.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/flight/FlightStatus.kt
@@ -1,6 +1,7 @@
 package ch.epfl.skysync.models.flight
 
 import androidx.compose.ui.graphics.Color
+import ch.epfl.skysync.models.user.User
 import ch.epfl.skysync.ui.theme.lightBlue
 import ch.epfl.skysync.ui.theme.lightBrown
 import ch.epfl.skysync.ui.theme.lightGray
@@ -17,5 +18,21 @@ enum class FlightStatus(val text: String, val displayColor: Color) {
 
   override fun toString(): String {
     return text
+  }
+  companion object {
+    /**
+     * updates the status of all FinishedFlights and Filters out the flights that are completed
+     */
+    fun filterCompletedFlights(flights: List<Flight>, user: User): List<Flight> {
+      return flights
+        .map {
+          if (it is FinishedFlight) {
+            it.updateFlightStatus(user)
+          } else {
+            it
+          }
+        }
+        .filter { it.getFlightStatus() != COMPLETED }
+    }
   }
 }

--- a/app/src/main/java/ch/epfl/skysync/models/flight/Team.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/flight/Team.kt
@@ -18,6 +18,13 @@ data class Team(val roles: List<Role>) {
     return roles.isNotEmpty() && roles.all { it.isAssigned() }
   }
 
+  /**
+   * @return the number of roles in the team
+   */
+  fun size(): Int {
+    return roles.size
+  }
+
   fun getUsers(): List<User> {
     return roles.mapNotNull { it.assignedUser }
   }

--- a/app/src/main/java/ch/epfl/skysync/models/flight/Team.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/flight/Team.kt
@@ -18,9 +18,7 @@ data class Team(val roles: List<Role>) {
     return roles.isNotEmpty() && roles.all { it.isAssigned() }
   }
 
-  /**
-   * @return the number of roles in the team
-   */
+  /** @return the number of roles in the team */
   fun size(): Int {
     return roles.size
   }

--- a/app/src/main/java/ch/epfl/skysync/models/reports/Report.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/reports/Report.kt
@@ -1,5 +1,6 @@
 package ch.epfl.skysync.models.reports
 
+import ch.epfl.skysync.models.user.User
 import java.util.Date
 
 interface Report {
@@ -9,4 +10,12 @@ interface Report {
   val end: Date
   val pauseDuration: Int // in milliseconds
   val comments: String
+
+  /**
+   * @param user the user to check if the report was authored by
+   * @return true if this report was authored by the given user
+   */
+  fun authoredBy(user: User): Boolean {
+    return author == user.id
+  }
 }

--- a/app/src/main/java/ch/epfl/skysync/viewmodel/FlightsViewModel.kt
+++ b/app/src/main/java/ch/epfl/skysync/viewmodel/FlightsViewModel.kt
@@ -13,6 +13,7 @@ import ch.epfl.skysync.models.calendar.TimeSlot
 import ch.epfl.skysync.models.flight.Balloon
 import ch.epfl.skysync.models.flight.Basket
 import ch.epfl.skysync.models.flight.ConfirmedFlight
+import ch.epfl.skysync.models.flight.FinishedFlight
 import ch.epfl.skysync.models.flight.Flight
 import ch.epfl.skysync.models.flight.FlightType
 import ch.epfl.skysync.models.flight.PlannedFlight
@@ -106,9 +107,16 @@ class FlightsViewModel(
           Log.d("FlightsViewModel", "Admin user loaded")
           _currentFlights.value = repository.flightTable.getAll(onError = { onError(it) })
         } else if (_currentUser.value is Pilot || _currentUser.value is Crew) {
-          _currentFlights.value =
+          val fetchedFlights =
               repository.userTable.retrieveAssignedFlights(
                   repository.flightTable, userId ?: UNSET_ID, onError = { onError(it) })
+            _currentFlights.value = fetchedFlights.map {
+                if (it is FinishedFlight) {
+                    it.updateFlightStatus(_currentUser.value!!)
+                } else {
+                    it
+                }
+            }
           Log.d("FlightsViewModel", "Pilot or Crew user loaded")
         }
       }

--- a/app/src/main/java/ch/epfl/skysync/viewmodel/FlightsViewModel.kt
+++ b/app/src/main/java/ch/epfl/skysync/viewmodel/FlightsViewModel.kt
@@ -13,7 +13,6 @@ import ch.epfl.skysync.models.calendar.TimeSlot
 import ch.epfl.skysync.models.flight.Balloon
 import ch.epfl.skysync.models.flight.Basket
 import ch.epfl.skysync.models.flight.ConfirmedFlight
-import ch.epfl.skysync.models.flight.FinishedFlight
 import ch.epfl.skysync.models.flight.Flight
 import ch.epfl.skysync.models.flight.FlightStatus
 import ch.epfl.skysync.models.flight.FlightType

--- a/app/src/main/java/ch/epfl/skysync/viewmodel/FlightsViewModel.kt
+++ b/app/src/main/java/ch/epfl/skysync/viewmodel/FlightsViewModel.kt
@@ -15,6 +15,7 @@ import ch.epfl.skysync.models.flight.Basket
 import ch.epfl.skysync.models.flight.ConfirmedFlight
 import ch.epfl.skysync.models.flight.FinishedFlight
 import ch.epfl.skysync.models.flight.Flight
+import ch.epfl.skysync.models.flight.FlightStatus
 import ch.epfl.skysync.models.flight.FlightType
 import ch.epfl.skysync.models.flight.PlannedFlight
 import ch.epfl.skysync.models.flight.Vehicle
@@ -112,7 +113,7 @@ class FlightsViewModel(
           Log.d("FlightsViewModel", "Pilot or Crew user loaded")
         }
         _currentFlights.value =
-            FinishedFlight.filterCompletedFlights(fetchedFlights, _currentUser.value!!)
+            FlightStatus.filterCompletedFlights(fetchedFlights, _currentUser.value!!)
       }
 
   /** updates */

--- a/app/src/main/java/ch/epfl/skysync/viewmodel/FlightsViewModel.kt
+++ b/app/src/main/java/ch/epfl/skysync/viewmodel/FlightsViewModel.kt
@@ -98,6 +98,10 @@ class FlightsViewModel(
     refreshFilteredByDateAndTimeSlot()
   }
 
+  /**
+   * refreshes the user and the flights. Finished flights are filtered to contain only the
+   * uncompleted ones
+   */
   fun refreshUserAndFlights() =
       viewModelScope.launch {
         _currentUser.value = repository.userTable.get(userId!!, onError = { onError(it) })

--- a/app/src/main/java/ch/epfl/skysync/viewmodel/FlightsViewModel.kt
+++ b/app/src/main/java/ch/epfl/skysync/viewmodel/FlightsViewModel.kt
@@ -100,7 +100,7 @@ class FlightsViewModel(
 
   fun refreshUserAndFlights() =
       viewModelScope.launch {
-        _currentUser.value = repository.userTable.get(userId ?: UNSET_ID, onError = { onError(it) })
+        _currentUser.value = repository.userTable.get(userId!!, onError = { onError(it) })
         lateinit var fetchedFlights: List<Flight>
         if (_currentUser.value!! is Admin) {
           Log.d("FlightsViewModel", "Admin user loaded")
@@ -108,7 +108,7 @@ class FlightsViewModel(
         } else {
           fetchedFlights =
               repository.userTable.retrieveAssignedFlights(
-                  repository.flightTable, userId ?: UNSET_ID, onError = { onError(it) })
+                  repository.flightTable, userId, onError = { onError(it) })
           Log.d("FlightsViewModel", "Pilot or Crew user loaded")
         }
         _currentFlights.value =

--- a/app/src/test/java/ch/epfl/skysync/model/flight/TestFinishedFlight.kt
+++ b/app/src/test/java/ch/epfl/skysync/model/flight/TestFinishedFlight.kt
@@ -1,0 +1,69 @@
+package ch.epfl.skysync.model.flight
+
+import ch.epfl.skysync.database.DateUtility
+import ch.epfl.skysync.models.UNSET_ID
+import ch.epfl.skysync.models.calendar.TimeSlot
+import ch.epfl.skysync.models.flight.Balloon
+import ch.epfl.skysync.models.flight.BalloonQualification
+import ch.epfl.skysync.models.flight.Basket
+import ch.epfl.skysync.models.flight.FinishedFlight
+import ch.epfl.skysync.models.flight.FlightStatus
+import ch.epfl.skysync.models.flight.FlightType
+import ch.epfl.skysync.models.flight.Role
+import ch.epfl.skysync.models.flight.RoleType
+import ch.epfl.skysync.models.flight.Team
+import ch.epfl.skysync.models.location.FlightTrace
+import ch.epfl.skysync.models.location.LocationPoint
+import ch.epfl.skysync.models.user.Crew
+import ch.epfl.skysync.models.user.User
+import java.time.LocalDate
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Example local unit test, which will execute on the development machine (host).
+ *
+ * See [testing documentation](http://d.android.com/tools/testing).
+ */
+class TestFinishedFlight {
+
+  lateinit var crew: User
+  lateinit var finishedFlight: FinishedFlight
+
+  @Before
+  fun setUp() {
+    crew =
+        Crew(
+            id = "1",
+            firstname = "Paul",
+            lastname = "Panzer",
+            email = "paul.panzer@gmail.com",
+        )
+
+    finishedFlight =
+        FinishedFlight(
+            nPassengers = 3,
+            team = Team(roles = listOf(Role(RoleType.PILOT, pilot1), Role(RoleType.CREW, crew1))),
+            flightType = FlightType.FONDUE,
+            balloon = Balloon("2", BalloonQualification.LARGE),
+            basket = Basket("3", false),
+            date = LocalDate.of(2001, 1, 2),
+            timeSlot = TimeSlot.PM,
+            vehicles = emptyList(),
+            id = "1",
+            takeOffTime = DateUtility.localDateToDate(LocalDate.of(2001, 1, 1)),
+            takeOffLocation = LocationPoint(1, 0.0, 0.1),
+            landingTime = DateUtility.localDateToDate(LocalDate.of(2000, 2, 1)),
+            landingLocation = LocationPoint(1, 0.0, 0.1),
+            flightTime = 1001,
+            reportId = emptyList(),
+            flightTrace = FlightTrace(UNSET_ID, emptyList()),
+            thisFlightStatus = FlightStatus.MISSING_REPORT)
+  }
+
+  @Test
+  fun `updateFlightStatusForWithCondition returns same instance if status is not changed`() {
+    assertEquals(finishedFlight.updateFlightStatus(crew), finishedFlight)
+  }
+}

--- a/app/src/test/java/ch/epfl/skysync/model/flight/TestFlightStatus.kt
+++ b/app/src/test/java/ch/epfl/skysync/model/flight/TestFlightStatus.kt
@@ -19,97 +19,91 @@ import ch.epfl.skysync.models.reports.FlightReport
 import ch.epfl.skysync.models.user.Admin
 import ch.epfl.skysync.models.user.Crew
 import ch.epfl.skysync.models.user.Pilot
-import org.junit.Assert.*
-import org.junit.Test
 import java.time.LocalDate
 import java.time.LocalTime
+import org.junit.Assert.*
+import org.junit.Test
 
 /**
  * Example local unit test, which will execute on the development machine (host).
  *
  * See [testing documentation](http://d.android.com/tools/testing).
  */
-
 val crew1 = Crew("1", "John", "Doe", "")
 val admin1 = Admin("3", "Betina", "Doe", "")
 val pilot1 = Pilot("2", "Jane", "Doe", "", qualification = BalloonQualification.LARGE)
 
+class TestFlightStatus {
+  val plannedFlight =
+      PlannedFlight(
+          nPassengers = 2,
+          team = Team(roles = listOf(Role(RoleType.PILOT, pilot1), Role(RoleType.CREW, crew1))),
+          flightType = FlightType.DISCOVERY,
+          balloon = Balloon("1", BalloonQualification.LARGE),
+          basket = Basket("1", true),
+          date = LocalDate.of(2000, 1, 1),
+          timeSlot = TimeSlot.AM,
+          vehicles = emptyList(),
+          id = "1")
+  val finishedFlight =
+      FinishedFlight(
+          nPassengers = 2,
+          team = Team(roles = listOf(Role(RoleType.PILOT, pilot1), Role(RoleType.CREW, crew1))),
+          flightType = FlightType.DISCOVERY,
+          balloon = Balloon("1", BalloonQualification.LARGE),
+          basket = Basket("1", true),
+          date = LocalDate.of(2000, 1, 1),
+          timeSlot = TimeSlot.AM,
+          vehicles = emptyList(),
+          id = "1",
+          takeOffTime = DateUtility.localDateToDate(LocalDate.of(2000, 1, 1)),
+          takeOffLocation = LocationPoint(1, 0.0, 0.0),
+          landingTime = DateUtility.localDateToDate(LocalDate.of(2000, 1, 1)),
+          landingLocation = LocationPoint(1, 0.0, 0.0),
+          flightTime = 1000,
+          reportId = emptyList(),
+          flightTrace = FlightTrace(UNSET_ID, emptyList()),
+          thisFlightStatus = FlightStatus.MISSING_REPORT)
 
-
-  class TestFlightStatus {
-    val plannedFlight = PlannedFlight(
-      nPassengers = 2,
-      team = Team(roles = listOf(Role(RoleType.PILOT, pilot1), Role(RoleType.CREW, crew1))),
-      flightType = FlightType.DISCOVERY,
-      balloon = Balloon("1", BalloonQualification.LARGE),
-      basket = Basket("1", true),
-      date = LocalDate.of(2000, 1, 1),
-      timeSlot = TimeSlot.AM,
-      vehicles = emptyList(),
-      id = "1"
-    )
-    val finishedFlight = FinishedFlight(
-      nPassengers = 2,
-      team = Team(roles = listOf(Role(RoleType.PILOT, pilot1), Role(RoleType.CREW, crew1))),
-      flightType = FlightType.DISCOVERY,
-      balloon = Balloon("1", BalloonQualification.LARGE),
-      basket = Basket("1", true),
-      date = LocalDate.of(2000, 1, 1),
-      timeSlot = TimeSlot.AM,
-      vehicles = emptyList(),
-      id = "1",
-      takeOffTime = DateUtility.localDateToDate(LocalDate.of(2000, 1, 1)),
-      takeOffLocation = LocationPoint(1, 0.0, 0.0),
-      landingTime = DateUtility.localDateToDate(LocalDate.of(2000, 1, 1)),
-      landingLocation = LocationPoint(1, 0.0, 0.0),
-      flightTime = 1000,
-      reportId = emptyList(),
-      flightTrace = FlightTrace(UNSET_ID, emptyList()),
-      thisFlightStatus = FlightStatus.MISSING_REPORT
-    )
-
-    val report1 =
+  val report1 =
       FlightReport(
-        author = crew1.id,
-        begin =
-        DateUtility.localDateAndTimeToDate(
-          LocalDate.of(2022, 12, 11),
-          LocalTime.of(23, 0, 1),
-        ),
-        end =
-        DateUtility.localDateAndTimeToDate(
-          LocalDate.of(2022, 12, 11),
-          LocalTime.of(14, 1, 0),
-        ),
-        pauseDuration = 101,
-        comments = "hola test",
+          author = crew1.id,
+          begin =
+              DateUtility.localDateAndTimeToDate(
+                  LocalDate.of(2022, 12, 11),
+                  LocalTime.of(23, 0, 1),
+              ),
+          end =
+              DateUtility.localDateAndTimeToDate(
+                  LocalDate.of(2022, 12, 11),
+                  LocalTime.of(14, 1, 0),
+              ),
+          pauseDuration = 101,
+          comments = "hola test",
       )
 
-
-    @Test
-    fun `no filtering is done if no confirmed present`() {
-      val noConfirmed = listOf(finishedFlight, plannedFlight)
-      var filtered = FlightStatus.filterCompletedFlights(noConfirmed, crew1)
-      assertEquals(filtered, noConfirmed)
-    }
-
-    @Test
-    fun `filtering is done if confirmed present for admin`() {
-      val confirmedFlight = finishedFlight.copy(team = Team(roles = listOf()))
-      var filtered = FlightStatus.filterCompletedFlights(listOf(confirmedFlight, plannedFlight), admin1)
-      assertEquals(listOf(plannedFlight), filtered)
-    }
-    @Test
-    fun `filtering is done if confirmed present for crew`() {
-      val confirmedFlight = finishedFlight.copy(
-        team = Team(roles = listOf(Role(RoleType.CREW, crew1))),
-        reportId = listOf(report1)
-      )
-      var filtered = FlightStatus.filterCompletedFlights(listOf(confirmedFlight, plannedFlight), crew1)
-      assertEquals(listOf(plannedFlight), filtered)
-    }
-
+  @Test
+  fun `no filtering is done if no confirmed present`() {
+    val noConfirmed = listOf(finishedFlight, plannedFlight)
+    var filtered = FlightStatus.filterCompletedFlights(noConfirmed, crew1)
+    assertEquals(filtered, noConfirmed)
   }
 
+  @Test
+  fun `filtering is done if confirmed present for admin`() {
+    val confirmedFlight = finishedFlight.copy(team = Team(roles = listOf()))
+    var filtered =
+        FlightStatus.filterCompletedFlights(listOf(confirmedFlight, plannedFlight), admin1)
+    assertEquals(listOf(plannedFlight), filtered)
+  }
 
-
+  @Test
+  fun `filtering is done if confirmed present for crew`() {
+    val confirmedFlight =
+        finishedFlight.copy(
+            team = Team(roles = listOf(Role(RoleType.CREW, crew1))), reportId = listOf(report1))
+    var filtered =
+        FlightStatus.filterCompletedFlights(listOf(confirmedFlight, plannedFlight), crew1)
+    assertEquals(listOf(plannedFlight), filtered)
+  }
+}

--- a/app/src/test/java/ch/epfl/skysync/model/flight/TestFlightStatus.kt
+++ b/app/src/test/java/ch/epfl/skysync/model/flight/TestFlightStatus.kt
@@ -1,0 +1,115 @@
+package ch.epfl.skysync.model.flight
+
+import ch.epfl.skysync.database.DateUtility
+import ch.epfl.skysync.models.UNSET_ID
+import ch.epfl.skysync.models.calendar.TimeSlot
+import ch.epfl.skysync.models.flight.Balloon
+import ch.epfl.skysync.models.flight.BalloonQualification
+import ch.epfl.skysync.models.flight.Basket
+import ch.epfl.skysync.models.flight.FinishedFlight
+import ch.epfl.skysync.models.flight.FlightStatus
+import ch.epfl.skysync.models.flight.FlightType
+import ch.epfl.skysync.models.flight.PlannedFlight
+import ch.epfl.skysync.models.flight.Role
+import ch.epfl.skysync.models.flight.RoleType
+import ch.epfl.skysync.models.flight.Team
+import ch.epfl.skysync.models.location.FlightTrace
+import ch.epfl.skysync.models.location.LocationPoint
+import ch.epfl.skysync.models.reports.FlightReport
+import ch.epfl.skysync.models.user.Admin
+import ch.epfl.skysync.models.user.Crew
+import ch.epfl.skysync.models.user.Pilot
+import org.junit.Assert.*
+import org.junit.Test
+import java.time.LocalDate
+import java.time.LocalTime
+
+/**
+ * Example local unit test, which will execute on the development machine (host).
+ *
+ * See [testing documentation](http://d.android.com/tools/testing).
+ */
+
+val crew1 = Crew("1", "John", "Doe", "")
+val admin1 = Admin("3", "Betina", "Doe", "")
+val pilot1 = Pilot("2", "Jane", "Doe", "", qualification = BalloonQualification.LARGE)
+
+
+
+  class TestFlightStatus {
+    val plannedFlight = PlannedFlight(
+      nPassengers = 2,
+      team = Team(roles = listOf(Role(RoleType.PILOT, pilot1), Role(RoleType.CREW, crew1))),
+      flightType = FlightType.DISCOVERY,
+      balloon = Balloon("1", BalloonQualification.LARGE),
+      basket = Basket("1", true),
+      date = LocalDate.of(2000, 1, 1),
+      timeSlot = TimeSlot.AM,
+      vehicles = emptyList(),
+      id = "1"
+    )
+    val finishedFlight = FinishedFlight(
+      nPassengers = 2,
+      team = Team(roles = listOf(Role(RoleType.PILOT, pilot1), Role(RoleType.CREW, crew1))),
+      flightType = FlightType.DISCOVERY,
+      balloon = Balloon("1", BalloonQualification.LARGE),
+      basket = Basket("1", true),
+      date = LocalDate.of(2000, 1, 1),
+      timeSlot = TimeSlot.AM,
+      vehicles = emptyList(),
+      id = "1",
+      takeOffTime = DateUtility.localDateToDate(LocalDate.of(2000, 1, 1)),
+      takeOffLocation = LocationPoint(1, 0.0, 0.0),
+      landingTime = DateUtility.localDateToDate(LocalDate.of(2000, 1, 1)),
+      landingLocation = LocationPoint(1, 0.0, 0.0),
+      flightTime = 1000,
+      reportId = emptyList(),
+      flightTrace = FlightTrace(UNSET_ID, emptyList()),
+      thisFlightStatus = FlightStatus.MISSING_REPORT
+    )
+
+    val report1 =
+      FlightReport(
+        author = crew1.id,
+        begin =
+        DateUtility.localDateAndTimeToDate(
+          LocalDate.of(2022, 12, 11),
+          LocalTime.of(23, 0, 1),
+        ),
+        end =
+        DateUtility.localDateAndTimeToDate(
+          LocalDate.of(2022, 12, 11),
+          LocalTime.of(14, 1, 0),
+        ),
+        pauseDuration = 101,
+        comments = "hola test",
+      )
+
+
+    @Test
+    fun `no filtering is done if no confirmed present`() {
+      val noConfirmed = listOf(finishedFlight, plannedFlight)
+      var filtered = FlightStatus.filterCompletedFlights(noConfirmed, crew1)
+      assertEquals(filtered, noConfirmed)
+    }
+
+    @Test
+    fun `filtering is done if confirmed present for admin`() {
+      val confirmedFlight = finishedFlight.copy(team = Team(roles = listOf()))
+      var filtered = FlightStatus.filterCompletedFlights(listOf(confirmedFlight, plannedFlight), admin1)
+      assertEquals(listOf(plannedFlight), filtered)
+    }
+    @Test
+    fun `filtering is done if confirmed present for crew`() {
+      val confirmedFlight = finishedFlight.copy(
+        team = Team(roles = listOf(Role(RoleType.CREW, crew1))),
+        reportId = listOf(report1)
+      )
+      var filtered = FlightStatus.filterCompletedFlights(listOf(confirmedFlight, plannedFlight), crew1)
+      assertEquals(listOf(plannedFlight), filtered)
+    }
+
+  }
+
+
+


### PR DESCRIPTION
# filter `FinishedFlight` for `COMPLETED` and `MISSING_REPORT`
- added function to update the `FlightStatus` of a `FinishedFlight` as a function of a user
For an `Admin` a `FinishedFlight` is considered `COMPLETED` once all team members have submitted their `Report`
For a `Crew/Pilot `it requires only the submission of the personal `Report` to have a `COMPLETED` finished flight
- 