### PR TITLE
User filtering

### DIFF
--- a/app/src/androidTest/java/ch/epfl/skysync/database/DatabaseSetup.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/database/DatabaseSetup.kt
@@ -118,6 +118,11 @@ class DatabaseSetup {
           email = "pilot3.pilot@skysnc.ch",
           qualification = BalloonQualification.SMALL)
 
+  var allUsers = listOf(crew1, crew2, pilot1, pilot2, pilot3, admin1, admin2)
+  val allCrews = allUsers.filterIsInstance<Crew>()
+  val allPilots = allUsers.filterIsInstance<Pilot>()
+  val allAdmins = allUsers.filterIsInstance<Admin>()
+
   var date1 = LocalDate.of(2024, 8, 14)
 
   // this the date of flight4, it needs to be today for the InFlightViewModel tests

--- a/app/src/androidTest/java/ch/epfl/skysync/screens/userManagement/UserManagementTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/screens/userManagement/UserManagementTest.kt
@@ -16,10 +16,15 @@ import ch.epfl.skysync.components.ContextConnectivityStatus
 import ch.epfl.skysync.database.DatabaseSetup
 import ch.epfl.skysync.database.FirestoreDatabase
 import ch.epfl.skysync.models.flight.RoleType
+import ch.epfl.skysync.models.user.Admin
+import ch.epfl.skysync.models.user.Crew
+import ch.epfl.skysync.models.user.Pilot
+import ch.epfl.skysync.models.user.User
 import ch.epfl.skysync.screens.admin.RoleFilter
 import ch.epfl.skysync.screens.admin.SearchBar
 import ch.epfl.skysync.screens.admin.UserCard
 import ch.epfl.skysync.screens.admin.UserManagementScreen
+import ch.epfl.skysync.screens.admin.displayMainRole
 import ch.epfl.skysync.viewmodel.UserManagementViewModel
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.test.runTest
@@ -48,9 +53,7 @@ class UserManagementTest {
     composeTestRule
         .onNodeWithText("${dbSetup.pilot1.firstname} ${dbSetup.pilot1.lastname}")
         .assertIsDisplayed()
-    composeTestRule
-        .onNodeWithText(dbSetup.pilot1.roleTypes.joinToString { it.name })
-        .assertIsDisplayed()
+    composeTestRule.onNodeWithText(displayMainRole(dbSetup.pilot1)).assertIsDisplayed()
   }
 
   @Test
@@ -88,6 +91,33 @@ class UserManagementTest {
     }
   }
 
+  private fun filterByRole(
+      currentRoleType: RoleType,
+      expectedUsers: List<User>,
+  ) {
+    val expectedNotDisplayedUsers =
+        when (expectedUsers[0]) {
+          is Admin -> expectedUsers.filterNot { user: User -> user is Admin }
+          is Pilot -> expectedUsers.filterNot { user: User -> user is Pilot }
+          is Crew -> expectedUsers.filterNot { user: User -> user is Crew }
+          else -> expectedUsers
+        }
+
+    composeTestRule.onNodeWithTag("UserManagementRoleFilterButton").performClick()
+    composeTestRule.onNodeWithTag("RoleTag${currentRoleType.description}").performClick()
+
+    expectedUsers.forEach {
+      composeTestRule
+          .onNodeWithTag("UserManagementLazyColumn")
+          .performScrollToNode(hasText("${it.firstname} ${it.lastname}"))
+      composeTestRule.onNodeWithText("${it.firstname} ${it.lastname}").assertIsDisplayed()
+    }
+
+    expectedNotDisplayedUsers.forEach {
+      composeTestRule.onNodeWithText("${it.firstname} ${it.lastname}").assertDoesNotExist()
+    }
+  }
+
   @Test
   fun roleFilterWorks() {
     composeTestRule.setContent {
@@ -98,24 +128,40 @@ class UserManagementTest {
       val connectivityStatus = remember { ContextConnectivityStatus(context) }
       UserManagementScreen(rememberNavController(), userManagementViewModel, connectivityStatus)
     }
-    composeTestRule.onNodeWithText("Filter by role").performClick()
-    composeTestRule.onNodeWithText("Pilot").performClick()
-    dbSetup.allPilots.forEach {
-      composeTestRule
-          .onNodeWithTag("UserManagementLazyColumn")
-          .performScrollToNode(hasText("${it.firstname} ${it.lastname}"))
-      composeTestRule.onNodeWithText("${it.firstname} ${it.lastname}").assertIsDisplayed()
-    }
 
-    dbSetup.allCrews.forEach {
-      composeTestRule.onNodeWithText("${it.firstname} ${it.lastname}").assertDoesNotExist()
-    }
-    dbSetup.allAdmins.forEach {
-      composeTestRule.onNodeWithText("${it.firstname} ${it.lastname}").assertDoesNotExist()
-    }
-    composeTestRule.onNodeWithText("Pilot").performClick()
-    composeTestRule.onNodeWithText(RoleType.MAITRE_FONDUE.description).performClick()
+    // Filter the Pilots
+    filterByRole(currentRoleType = RoleType.PILOT, expectedUsers = dbSetup.allPilots)
+
+    // Filter the admins
+    filterByRole(currentRoleType = RoleType.ADMIN, expectedUsers = dbSetup.allAdmins)
+
+    composeTestRule.onNodeWithTag("UserManagementRoleFilterButton").performClick()
+    composeTestRule.onNodeWithTag("RoleTag${RoleType.MAITRE_FONDUE.description}").performClick()
     composeTestRule.onNodeWithText("No such user exists").assertIsDisplayed()
+  }
+
+  @Test
+  fun roleFilterAndQuery() {
+    composeTestRule.setContent {
+      userManagementViewModel =
+          UserManagementViewModel.createViewModel(repository, dbSetup.admin1.id)
+      userManagementViewModel.refresh()
+      val context = LocalContext.current
+      val connectivityStatus = remember { ContextConnectivityStatus(context) }
+      UserManagementScreen(rememberNavController(), userManagementViewModel, connectivityStatus)
+    }
+    // Filter the Pilots
+    filterByRole(currentRoleType = RoleType.PILOT, expectedUsers = dbSetup.allPilots)
+    composeTestRule.onNodeWithText("Search users").performTextInput(dbSetup.pilot1.firstname)
+    composeTestRule
+        .onNodeWithText("${dbSetup.pilot1.firstname} ${dbSetup.pilot1.lastname}")
+        .assertIsDisplayed()
+
+    dbSetup.allUsers
+        .filter { user -> user != dbSetup.pilot1 }
+        .forEach {
+          composeTestRule.onNodeWithText("${it.firstname} ${it.lastname}").assertDoesNotExist()
+        }
   }
 
   @Test

--- a/app/src/main/java/ch/epfl/skysync/models/flight/RoleType.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/flight/RoleType.kt
@@ -1,6 +1,7 @@
 package ch.epfl.skysync.models.flight
 
 enum class RoleType(val description: String) {
+  ADMIN("Admin"),
   PILOT("Pilot"),
   CREW("Crew"),
   SERVICE_ON_BOARD("Service on board"),

--- a/app/src/main/java/ch/epfl/skysync/models/user/Admin.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/user/Admin.kt
@@ -8,7 +8,7 @@ data class Admin(
     override val firstname: String,
     override val lastname: String,
     override val email: String,
-    override val roleTypes: Set<RoleType> = setOf(),
+    override val roleTypes: Set<RoleType> = setOf(RoleType.ADMIN),
 ) : User {
   override fun addRoleType(roleType: RoleType): Admin {
     return this.copy(roleTypes = roleTypes + roleType)

--- a/app/src/main/java/ch/epfl/skysync/screens/admin/AdminStats.kt
+++ b/app/src/main/java/ch/epfl/skysync/screens/admin/AdminStats.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import ch.epfl.skysync.components.FlightsList
-import ch.epfl.skysync.navigation.BottomBar
+import ch.epfl.skysync.navigation.AdminBottomBar
 import ch.epfl.skysync.navigation.Route
 import ch.epfl.skysync.ui.theme.lightOrange
 import ch.epfl.skysync.viewmodel.FinishedFlightsViewModel
@@ -19,7 +19,7 @@ fun AdminStatsScreen(navController: NavHostController, viewModel: FinishedFlight
   val finishedFlights by viewModel.currentFlights.collectAsStateWithLifecycle()
   Scaffold(
       modifier = Modifier.fillMaxSize(),
-      bottomBar = { BottomBar(navController) },
+      bottomBar = { AdminBottomBar(navController) },
       floatingActionButton = {},
       floatingActionButtonPosition = FabPosition.End,
   ) { padding ->

--- a/app/src/main/java/ch/epfl/skysync/screens/admin/UserManagement.kt
+++ b/app/src/main/java/ch/epfl/skysync/screens/admin/UserManagement.kt
@@ -84,9 +84,7 @@ fun UserCard(user: User, onUserClick: (String) -> Unit) {
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween) {
           Text(
-              "${user.firstname} ${user.lastname}",
-              fontWeight = FontWeight.Bold,
-              style = MaterialTheme.typography.bodyLarge)
+              user.name(), fontWeight = FontWeight.Bold, style = MaterialTheme.typography.bodyLarge)
           Text(displayMainRole(user))
         }
   }

--- a/app/src/main/java/ch/epfl/skysync/viewmodel/UserManagementViewModel.kt
+++ b/app/src/main/java/ch/epfl/skysync/viewmodel/UserManagementViewModel.kt
@@ -92,8 +92,7 @@ class UserManagementViewModel(
   fun filterByQueryAndRole(query: String, selectedRole: RoleType?) {
     _filteredUsers.value =
         _allUsers.value.filter {
-          (query.isEmpty() ||
-              "${it.firstname} ${it.lastname}".contains(query, ignoreCase = true)) &&
+          (query.isEmpty() || it.name().contains(query, ignoreCase = true)) &&
               (selectedRole == null || it.roleTypes.contains(selectedRole))
         }
   }


### PR DESCRIPTION
## Bug 
In the `UserManagementScreen` (Admin) when filtering users by role, there was always a "No such user exists" message.

## Problem
We added the users manually to the database and did never fill the `userRoles` field, but it was used to filter. 
When using `DatabaseSetup`, everything works fine.

## Solution
* Added manually the roles in the database. 
* Added a role `Admin` in `RoleTypes` 

## Other changements
* Moved the filtering logic in the `UserManagementViewModel`
* Small refactoring of `UserManagementScreen`
* Displays the main role of the user (Admin, Pilot, Crew) and not the whole set of `roleTypes`
* Replacement of `BottomBar` with `AdminBottomBar` in `AdminStats`.

close #406 
