### PR TITLE
refactor the UserManagement UI

### DIFF
--- a/app/src/androidTest/java/ch/epfl/skysync/screens/userManagement/UserManagementTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/screens/userManagement/UserManagementTest.kt
@@ -52,7 +52,7 @@ class UserManagementTest {
     composeTestRule
         .onNodeWithText("${dbSetup.pilot1.firstname} ${dbSetup.pilot1.lastname}")
         .assertIsDisplayed()
-    // composeTestRule.onNodeWithText(displayMainRole(dbSetup.pilot1)).assertIsDisplayed()
+    composeTestRule.onNodeWithText(dbSetup.pilot1.displayRoleName()).assertIsDisplayed()
   }
 
   @Test
@@ -130,7 +130,7 @@ class UserManagementTest {
     filterByRole(currentRoleType = RoleType.PILOT, expectedUsers = dbSetup.allPilots)
 
     // Filter the admins
-    // filterByRole(currentRoleType = RoleType.ADMIN, expectedUsers = dbSetup.allAdmins)
+    filterByRole(currentRoleType = RoleType.ADMIN, expectedUsers = dbSetup.allAdmins)
 
     composeTestRule.onNodeWithTag("UserManagementRoleFilterButton").performClick()
     composeTestRule.onNodeWithTag("RoleTag${RoleType.MAITRE_FONDUE.description}").performClick()

--- a/app/src/androidTest/java/ch/epfl/skysync/screens/userManagement/UserManagementTest.kt
+++ b/app/src/androidTest/java/ch/epfl/skysync/screens/userManagement/UserManagementTest.kt
@@ -24,7 +24,6 @@ import ch.epfl.skysync.screens.admin.RoleFilter
 import ch.epfl.skysync.screens.admin.SearchBar
 import ch.epfl.skysync.screens.admin.UserCard
 import ch.epfl.skysync.screens.admin.UserManagementScreen
-import ch.epfl.skysync.screens.admin.displayMainRole
 import ch.epfl.skysync.viewmodel.UserManagementViewModel
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.test.runTest
@@ -53,7 +52,7 @@ class UserManagementTest {
     composeTestRule
         .onNodeWithText("${dbSetup.pilot1.firstname} ${dbSetup.pilot1.lastname}")
         .assertIsDisplayed()
-    composeTestRule.onNodeWithText(displayMainRole(dbSetup.pilot1)).assertIsDisplayed()
+    // composeTestRule.onNodeWithText(displayMainRole(dbSetup.pilot1)).assertIsDisplayed()
   }
 
   @Test
@@ -81,9 +80,7 @@ class UserManagementTest {
 
   @Test
   fun roleFilterDisplaysRoles() {
-    composeTestRule.setContent {
-      RoleFilter(onRoleSelected = {}, roles = RoleType.entries, count = 0)
-    }
+    composeTestRule.setContent { RoleFilter(onRoleSelected = {}, roles = RoleType.entries) }
 
     composeTestRule.onNodeWithText("Filter by role").performClick()
     RoleType.entries.forEach { roleType ->
@@ -133,7 +130,7 @@ class UserManagementTest {
     filterByRole(currentRoleType = RoleType.PILOT, expectedUsers = dbSetup.allPilots)
 
     // Filter the admins
-    filterByRole(currentRoleType = RoleType.ADMIN, expectedUsers = dbSetup.allAdmins)
+    // filterByRole(currentRoleType = RoleType.ADMIN, expectedUsers = dbSetup.allAdmins)
 
     composeTestRule.onNodeWithTag("UserManagementRoleFilterButton").performClick()
     composeTestRule.onNodeWithTag("RoleTag${RoleType.MAITRE_FONDUE.description}").performClick()

--- a/app/src/main/java/ch/epfl/skysync/components/FlightsList.kt
+++ b/app/src/main/java/ch/epfl/skysync/components/FlightsList.kt
@@ -39,7 +39,6 @@ fun FlightsList(
   }
 }
 
-
 /**
  * shows a list of flights. Distinguishes 3 cases:
  * 1) flights == null: shows a loading component

--- a/app/src/main/java/ch/epfl/skysync/components/FlightsList.kt
+++ b/app/src/main/java/ch/epfl/skysync/components/FlightsList.kt
@@ -1,6 +1,5 @@
 package ch.epfl.skysync.components
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -20,10 +19,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import ch.epfl.skysync.models.flight.Flight
-import ch.epfl.skysync.ui.theme.TOP_CORNER_ROUNDED
 
 /** shows a list of flights with a given title on the top and a banner color */
 @Composable
@@ -42,23 +39,6 @@ fun FlightsList(
   }
 }
 
-/** displays the top banner */
-@Composable
-fun TopBanner(topTitle: String, topBannerColor: Color, paddingValues: PaddingValues) {
-  Text(
-      text = topTitle,
-      style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.Bold),
-      modifier =
-          Modifier.background(color = topBannerColor, shape = TOP_CORNER_ROUNDED)
-              .fillMaxWidth()
-              .padding(
-                  top = paddingValues.calculateTopPadding() + 16.dp,
-                  start = 16.dp,
-                  end = 16.dp,
-                  bottom = 16.dp),
-      color = Color.White,
-      textAlign = TextAlign.Center)
-}
 
 /**
  * shows a list of flights. Distinguishes 3 cases:

--- a/app/src/main/java/ch/epfl/skysync/components/GroupChat.kt
+++ b/app/src/main/java/ch/epfl/skysync/components/GroupChat.kt
@@ -41,12 +41,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import ch.epfl.skysync.models.message.GroupDetails
 import ch.epfl.skysync.models.message.MessageDateFormatter
-import ch.epfl.skysync.ui.theme.Purple40
+import ch.epfl.skysync.ui.theme.ScreenTitles
+import ch.epfl.skysync.ui.theme.getThemeColor
 import ch.epfl.skysync.ui.theme.lightGray
 import ch.epfl.skysync.ui.theme.lightOrange
 
@@ -68,8 +68,12 @@ fun GroupChat(
 ) {
   var searchQuery by remember { mutableStateOf("") }
   var activeGroupId by remember { mutableStateOf<String?>(null) }
-  Column(modifier = Modifier.fillMaxSize().padding(paddingValues).padding(16.dp)) {
-    GroupChatTopBar(isAdmin = isAdmin, paddingValues = paddingValues)
+  Column(modifier = Modifier
+      .fillMaxSize()
+      .padding(paddingValues)
+      .padding(16.dp)) {
+
+      TopBanner(topTitle = ScreenTitles.MESSAGES, topBannerColor = getThemeColor(isAdmin), paddingValues = paddingValues)
     Spacer(modifier = Modifier.fillMaxHeight(0.02f))
 
     OutlinedTextField(
@@ -79,7 +83,9 @@ fun GroupChat(
         colors =
             OutlinedTextFieldDefaults.colors(
                 focusedBorderColor = lightOrange, focusedLabelColor = lightOrange),
-        modifier = Modifier.fillMaxWidth().testTag("Search"),
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("Search"),
         keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done))
     val filteredGroups = groupList.filter { it.name.contains(searchQuery, ignoreCase = true) }
     Spacer(modifier = Modifier.fillMaxHeight(0.05f))
@@ -95,25 +101,6 @@ fun GroupChat(
           isAdmin)
     }
   }
-}
-/** Composable function to display the top bar of the group chat UI. */
-@Composable
-fun GroupChatTopBar(isAdmin: Boolean, paddingValues: PaddingValues) {
-  val color = if (isAdmin) lightOrange else Purple40
-  Text(
-      text = "Messages",
-      style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.Bold),
-      modifier =
-          Modifier.background(
-                  color = color, shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp))
-              .fillMaxWidth()
-              .padding(
-                  top = paddingValues.calculateTopPadding() + 16.dp,
-                  start = 16.dp,
-                  end = 16.dp,
-                  bottom = 16.dp),
-      color = Color.White,
-      textAlign = TextAlign.Center)
 }
 
 /**
@@ -137,17 +124,21 @@ fun GroupCard(
   val time = groupDetails.lastMessage?.let { MessageDateFormatter.format(it.date) } ?: ""
   Card(
       modifier =
-          Modifier.combinedClickable(
-                  onClick = { onClick(groupDetails) }, onLongClick = { onActivate() })
-              .fillMaxWidth()
-              .padding(vertical = 4.dp)
-              .testTag("GroupCard$testTag"),
+      Modifier
+          .combinedClickable(
+              onClick = { onClick(groupDetails) }, onLongClick = { onActivate() })
+          .fillMaxWidth()
+          .padding(vertical = 4.dp)
+          .testTag("GroupCard$testTag"),
       shape = RoundedCornerShape(8.dp),
       colors = CardDefaults.cardColors(containerColor = lightGray)) {
         Row(modifier = Modifier.padding(8.dp)) {
           Box(
               modifier =
-                  Modifier.size(40.dp).clip(CircleShape).background(groupDetails.color.toColor()!!),
+              Modifier
+                  .size(40.dp)
+                  .clip(CircleShape)
+                  .background(groupDetails.color.toColor()!!),
               contentAlignment = Alignment.Center) {
                 Icon(
                     imageVector = Icons.Default.Person,
@@ -179,7 +170,10 @@ fun GroupCard(
         if (isActive && isAdmin) {
           Button(
               onClick = { onDelete(groupDetails) },
-              modifier = Modifier.fillMaxWidth().padding(8.dp).testTag("DeleteButton$testTag")) {
+              modifier = Modifier
+                  .fillMaxWidth()
+                  .padding(8.dp)
+                  .testTag("DeleteButton$testTag")) {
                 Text("Delete Group")
               }
         }

--- a/app/src/main/java/ch/epfl/skysync/components/GroupChat.kt
+++ b/app/src/main/java/ch/epfl/skysync/components/GroupChat.kt
@@ -68,12 +68,11 @@ fun GroupChat(
 ) {
   var searchQuery by remember { mutableStateOf("") }
   var activeGroupId by remember { mutableStateOf<String?>(null) }
-  Column(modifier = Modifier
-      .fillMaxSize()
-      .padding(paddingValues)
-      .padding(16.dp)) {
-
-      TopBanner(topTitle = ScreenTitles.MESSAGES, topBannerColor = getThemeColor(isAdmin), paddingValues = paddingValues)
+  Column(modifier = Modifier.fillMaxSize().padding(paddingValues).padding(16.dp)) {
+    TopBanner(
+        topTitle = ScreenTitles.MESSAGES,
+        topBannerColor = getThemeColor(isAdmin),
+        paddingValues = paddingValues)
     Spacer(modifier = Modifier.fillMaxHeight(0.02f))
 
     OutlinedTextField(
@@ -83,9 +82,7 @@ fun GroupChat(
         colors =
             OutlinedTextFieldDefaults.colors(
                 focusedBorderColor = lightOrange, focusedLabelColor = lightOrange),
-        modifier = Modifier
-            .fillMaxWidth()
-            .testTag("Search"),
+        modifier = Modifier.fillMaxWidth().testTag("Search"),
         keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done))
     val filteredGroups = groupList.filter { it.name.contains(searchQuery, ignoreCase = true) }
     Spacer(modifier = Modifier.fillMaxHeight(0.05f))
@@ -124,21 +121,17 @@ fun GroupCard(
   val time = groupDetails.lastMessage?.let { MessageDateFormatter.format(it.date) } ?: ""
   Card(
       modifier =
-      Modifier
-          .combinedClickable(
-              onClick = { onClick(groupDetails) }, onLongClick = { onActivate() })
-          .fillMaxWidth()
-          .padding(vertical = 4.dp)
-          .testTag("GroupCard$testTag"),
+          Modifier.combinedClickable(
+                  onClick = { onClick(groupDetails) }, onLongClick = { onActivate() })
+              .fillMaxWidth()
+              .padding(vertical = 4.dp)
+              .testTag("GroupCard$testTag"),
       shape = RoundedCornerShape(8.dp),
       colors = CardDefaults.cardColors(containerColor = lightGray)) {
         Row(modifier = Modifier.padding(8.dp)) {
           Box(
               modifier =
-              Modifier
-                  .size(40.dp)
-                  .clip(CircleShape)
-                  .background(groupDetails.color.toColor()!!),
+                  Modifier.size(40.dp).clip(CircleShape).background(groupDetails.color.toColor()!!),
               contentAlignment = Alignment.Center) {
                 Icon(
                     imageVector = Icons.Default.Person,
@@ -170,10 +163,7 @@ fun GroupCard(
         if (isActive && isAdmin) {
           Button(
               onClick = { onDelete(groupDetails) },
-              modifier = Modifier
-                  .fillMaxWidth()
-                  .padding(8.dp)
-                  .testTag("DeleteButton$testTag")) {
+              modifier = Modifier.fillMaxWidth().padding(8.dp).testTag("DeleteButton$testTag")) {
                 Text("Delete Group")
               }
         }

--- a/app/src/main/java/ch/epfl/skysync/components/TopBanner.kt
+++ b/app/src/main/java/ch/epfl/skysync/components/TopBanner.kt
@@ -1,0 +1,37 @@
+package ch.epfl.skysync.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import ch.epfl.skysync.ui.theme.TOP_CORNER_ROUNDED
+
+/**
+ * displays a top banner
+ * @param topTitle the title of the banner
+ * @param topBannerColor the color of the banner
+ */
+@Composable
+fun TopBanner(topTitle: String, topBannerColor: Color, paddingValues: PaddingValues) {
+    Text(
+        text = topTitle,
+        style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.Bold),
+        modifier =
+        Modifier.background(color = topBannerColor, shape = TOP_CORNER_ROUNDED)
+            .fillMaxWidth()
+            .padding(
+                top = paddingValues.calculateTopPadding() + 16.dp,
+                start = 16.dp,
+                end = 16.dp,
+                bottom = 16.dp),
+        color = Color.White,
+        textAlign = TextAlign.Center)
+}

--- a/app/src/main/java/ch/epfl/skysync/components/TopBanner.kt
+++ b/app/src/main/java/ch/epfl/skysync/components/TopBanner.kt
@@ -16,22 +16,23 @@ import ch.epfl.skysync.ui.theme.TOP_CORNER_ROUNDED
 
 /**
  * displays a top banner
+ *
  * @param topTitle the title of the banner
  * @param topBannerColor the color of the banner
  */
 @Composable
 fun TopBanner(topTitle: String, topBannerColor: Color, paddingValues: PaddingValues) {
-    Text(
-        text = topTitle,
-        style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.Bold),
-        modifier =
-        Modifier.background(color = topBannerColor, shape = TOP_CORNER_ROUNDED)
-            .fillMaxWidth()
-            .padding(
-                top = paddingValues.calculateTopPadding() + 16.dp,
-                start = 16.dp,
-                end = 16.dp,
-                bottom = 16.dp),
-        color = Color.White,
-        textAlign = TextAlign.Center)
+  Text(
+      text = topTitle,
+      style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.Bold),
+      modifier =
+          Modifier.background(color = topBannerColor, shape = TOP_CORNER_ROUNDED)
+              .fillMaxWidth()
+              .padding(
+                  top = paddingValues.calculateTopPadding() + 16.dp,
+                  start = 16.dp,
+                  end = 16.dp,
+                  bottom = 16.dp),
+      color = Color.White,
+      textAlign = TextAlign.Center)
 }

--- a/app/src/main/java/ch/epfl/skysync/models/user/Admin.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/user/Admin.kt
@@ -1,9 +1,7 @@
 package ch.epfl.skysync.models.user
 
-import androidx.compose.ui.graphics.Color
 import ch.epfl.skysync.models.UNSET_ID
 import ch.epfl.skysync.models.flight.RoleType
-import ch.epfl.skysync.ui.theme.lightOrange
 
 data class Admin(
     override val id: String = UNSET_ID,
@@ -16,6 +14,5 @@ data class Admin(
     return this.copy(roleTypes = roleTypes + roleType)
   }
 
-    override fun displayRoleName(): String = "Admin"
-    override fun getThemeColor(): Color = lightOrange
+  override fun displayRoleName(): String = "Admin"
 }

--- a/app/src/main/java/ch/epfl/skysync/models/user/Admin.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/user/Admin.kt
@@ -1,7 +1,9 @@
 package ch.epfl.skysync.models.user
 
+import androidx.compose.ui.graphics.Color
 import ch.epfl.skysync.models.UNSET_ID
 import ch.epfl.skysync.models.flight.RoleType
+import ch.epfl.skysync.ui.theme.lightOrange
 
 data class Admin(
     override val id: String = UNSET_ID,
@@ -13,4 +15,7 @@ data class Admin(
   override fun addRoleType(roleType: RoleType): Admin {
     return this.copy(roleTypes = roleTypes + roleType)
   }
+
+    override fun displayRoleName(): String = "Admin"
+    override fun getThemeColor(): Color = lightOrange
 }

--- a/app/src/main/java/ch/epfl/skysync/models/user/Crew.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/user/Crew.kt
@@ -1,10 +1,7 @@
 package ch.epfl.skysync.models.user
 
-import androidx.compose.ui.graphics.Color
 import ch.epfl.skysync.models.UNSET_ID
 import ch.epfl.skysync.models.flight.RoleType
-import ch.epfl.skysync.ui.theme.Purple40
-import ch.epfl.skysync.ui.theme.lightViolet
 
 data class Crew(
     override val id: String = UNSET_ID,
@@ -17,7 +14,5 @@ data class Crew(
     return this.copy(roleTypes = roleTypes + roleType)
   }
 
-    override fun displayRoleName(): String = "Crew"
-    override fun getThemeColor(): Color = Purple40
-
+  override fun displayRoleName(): String = "Crew"
 }

--- a/app/src/main/java/ch/epfl/skysync/models/user/Crew.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/user/Crew.kt
@@ -1,7 +1,10 @@
 package ch.epfl.skysync.models.user
 
+import androidx.compose.ui.graphics.Color
 import ch.epfl.skysync.models.UNSET_ID
 import ch.epfl.skysync.models.flight.RoleType
+import ch.epfl.skysync.ui.theme.Purple40
+import ch.epfl.skysync.ui.theme.lightViolet
 
 data class Crew(
     override val id: String = UNSET_ID,
@@ -13,4 +16,8 @@ data class Crew(
   override fun addRoleType(roleType: RoleType): Crew {
     return this.copy(roleTypes = roleTypes + roleType)
   }
+
+    override fun displayRoleName(): String = "Crew"
+    override fun getThemeColor(): Color = Purple40
+
 }

--- a/app/src/main/java/ch/epfl/skysync/models/user/Pilot.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/user/Pilot.kt
@@ -1,8 +1,11 @@
 package ch.epfl.skysync.models.user
 
+import androidx.compose.ui.graphics.Color
 import ch.epfl.skysync.models.UNSET_ID
 import ch.epfl.skysync.models.flight.BalloonQualification
 import ch.epfl.skysync.models.flight.RoleType
+import ch.epfl.skysync.ui.theme.Purple40
+import ch.epfl.skysync.ui.theme.lightViolet
 
 data class Pilot(
     override val id: String = UNSET_ID,
@@ -16,4 +19,7 @@ data class Pilot(
   override fun addRoleType(roleType: RoleType): Pilot {
     return this.copy(roleTypes = roleTypes + roleType)
   }
+
+    override fun displayRoleName() = "Pilot"
+    override fun getThemeColor(): Color = Purple40
 }

--- a/app/src/main/java/ch/epfl/skysync/models/user/Pilot.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/user/Pilot.kt
@@ -1,11 +1,8 @@
 package ch.epfl.skysync.models.user
 
-import androidx.compose.ui.graphics.Color
 import ch.epfl.skysync.models.UNSET_ID
 import ch.epfl.skysync.models.flight.BalloonQualification
 import ch.epfl.skysync.models.flight.RoleType
-import ch.epfl.skysync.ui.theme.Purple40
-import ch.epfl.skysync.ui.theme.lightViolet
 
 data class Pilot(
     override val id: String = UNSET_ID,
@@ -20,6 +17,5 @@ data class Pilot(
     return this.copy(roleTypes = roleTypes + roleType)
   }
 
-    override fun displayRoleName() = "Pilot"
-    override fun getThemeColor(): Color = Purple40
+  override fun displayRoleName() = "Pilot"
 }

--- a/app/src/main/java/ch/epfl/skysync/models/user/User.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/user/User.kt
@@ -1,5 +1,6 @@
 package ch.epfl.skysync.models.user
 
+import androidx.compose.ui.graphics.Color
 import ch.epfl.skysync.models.flight.RoleType
 
 interface User {
@@ -16,4 +17,13 @@ interface User {
   }
 
   fun name(): String = "$firstname $lastname"
+
+  /**
+   * displays the name of a particular User class
+   */
+  fun displayRoleName(): String
+
+
+  fun getThemeColor(): Color
+
 }

--- a/app/src/main/java/ch/epfl/skysync/models/user/User.kt
+++ b/app/src/main/java/ch/epfl/skysync/models/user/User.kt
@@ -1,6 +1,5 @@
 package ch.epfl.skysync.models.user
 
-import androidx.compose.ui.graphics.Color
 import ch.epfl.skysync.models.flight.RoleType
 
 interface User {
@@ -18,12 +17,6 @@ interface User {
 
   fun name(): String = "$firstname $lastname"
 
-  /**
-   * displays the name of a particular User class
-   */
+  /** displays the name of a particular User class */
   fun displayRoleName(): String
-
-
-  fun getThemeColor(): Color
-
 }

--- a/app/src/main/java/ch/epfl/skysync/screens/admin/AddUser.kt
+++ b/app/src/main/java/ch/epfl/skysync/screens/admin/AddUser.kt
@@ -33,6 +33,7 @@ import ch.epfl.skysync.util.textInputValidation
 import ch.epfl.skysync.util.validateEmail
 import ch.epfl.skysync.viewmodel.UserManagementViewModel
 
+/** screen to add a user */
 @Composable
 fun AddUserScreen(navController: NavController, viewModel: UserManagementViewModel) {
   val title = "Add User"

--- a/app/src/main/java/ch/epfl/skysync/screens/admin/AdminHome.kt
+++ b/app/src/main/java/ch/epfl/skysync/screens/admin/AdminHome.kt
@@ -19,6 +19,7 @@ import ch.epfl.skysync.components.ConnectivityStatus
 import ch.epfl.skysync.components.FlightsList
 import ch.epfl.skysync.navigation.AdminBottomBar
 import ch.epfl.skysync.navigation.Route
+import ch.epfl.skysync.ui.theme.getThemeColor
 import ch.epfl.skysync.ui.theme.lightOrange
 import ch.epfl.skysync.viewmodel.FlightsViewModel
 
@@ -49,7 +50,7 @@ fun AdminHomeScreen(
       },
       floatingActionButtonPosition = FabPosition.End,
   ) { padding ->
-    FlightsList(currentFlights, lightOrange, padding, "Upcoming flights") { selectedFlight ->
+    FlightsList(currentFlights, getThemeColor(isAdmin = true), padding, "Upcoming flights") { selectedFlight ->
       navController.navigate(Route.ADMIN_FLIGHT_DETAILS + "/${selectedFlight}")
     }
   }

--- a/app/src/main/java/ch/epfl/skysync/screens/admin/AdminHome.kt
+++ b/app/src/main/java/ch/epfl/skysync/screens/admin/AdminHome.kt
@@ -50,7 +50,8 @@ fun AdminHomeScreen(
       },
       floatingActionButtonPosition = FabPosition.End,
   ) { padding ->
-    FlightsList(currentFlights, getThemeColor(isAdmin = true), padding, "Upcoming flights") { selectedFlight ->
+    FlightsList(currentFlights, getThemeColor(isAdmin = true), padding, "Upcoming flights") {
+        selectedFlight ->
       navController.navigate(Route.ADMIN_FLIGHT_DETAILS + "/${selectedFlight}")
     }
   }

--- a/app/src/main/java/ch/epfl/skysync/screens/admin/AdminStats.kt
+++ b/app/src/main/java/ch/epfl/skysync/screens/admin/AdminStats.kt
@@ -11,6 +11,8 @@ import androidx.navigation.NavHostController
 import ch.epfl.skysync.components.FlightsList
 import ch.epfl.skysync.navigation.AdminBottomBar
 import ch.epfl.skysync.navigation.Route
+import ch.epfl.skysync.ui.theme.ScreenTitles
+import ch.epfl.skysync.ui.theme.getThemeColor
 import ch.epfl.skysync.ui.theme.lightOrange
 import ch.epfl.skysync.viewmodel.FinishedFlightsViewModel
 
@@ -23,7 +25,7 @@ fun AdminStatsScreen(navController: NavHostController, viewModel: FinishedFlight
       floatingActionButton = {},
       floatingActionButtonPosition = FabPosition.End,
   ) { padding ->
-    FlightsList(finishedFlights, lightOrange, padding, "Flights History") { selectedFlight ->
+    FlightsList(finishedFlights, getThemeColor(isAdmin = true), padding, ScreenTitles.HISTORY) { selectedFlight ->
       navController.navigate(Route.ADMIN_FLIGHT_DETAILS + "/${selectedFlight}")
     }
   }

--- a/app/src/main/java/ch/epfl/skysync/screens/admin/AdminStats.kt
+++ b/app/src/main/java/ch/epfl/skysync/screens/admin/AdminStats.kt
@@ -13,7 +13,6 @@ import ch.epfl.skysync.navigation.AdminBottomBar
 import ch.epfl.skysync.navigation.Route
 import ch.epfl.skysync.ui.theme.ScreenTitles
 import ch.epfl.skysync.ui.theme.getThemeColor
-import ch.epfl.skysync.ui.theme.lightOrange
 import ch.epfl.skysync.viewmodel.FinishedFlightsViewModel
 
 @Composable
@@ -25,7 +24,8 @@ fun AdminStatsScreen(navController: NavHostController, viewModel: FinishedFlight
       floatingActionButton = {},
       floatingActionButtonPosition = FabPosition.End,
   ) { padding ->
-    FlightsList(finishedFlights, getThemeColor(isAdmin = true), padding, ScreenTitles.HISTORY) { selectedFlight ->
+    FlightsList(finishedFlights, getThemeColor(isAdmin = true), padding, ScreenTitles.HISTORY) {
+        selectedFlight ->
       navController.navigate(Route.ADMIN_FLIGHT_DETAILS + "/${selectedFlight}")
     }
   }

--- a/app/src/main/java/ch/epfl/skysync/screens/admin/UserManagement.kt
+++ b/app/src/main/java/ch/epfl/skysync/screens/admin/UserManagement.kt
@@ -42,10 +42,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import ch.epfl.skysync.components.ConnectivityStatus
 import ch.epfl.skysync.components.LoadingComponent
+import ch.epfl.skysync.components.TopBanner
 import ch.epfl.skysync.models.flight.RoleType
-import ch.epfl.skysync.models.user.Admin
-import ch.epfl.skysync.models.user.Crew
-import ch.epfl.skysync.models.user.Pilot
 import ch.epfl.skysync.models.user.User
 import ch.epfl.skysync.navigation.AdminBottomBar
 import ch.epfl.skysync.navigation.Route
@@ -54,14 +52,6 @@ import ch.epfl.skysync.ui.theme.lightOrange
 import ch.epfl.skysync.ui.theme.lightTurquoise
 import ch.epfl.skysync.viewmodel.UserManagementViewModel
 
-fun displayMainRole(user: User): String {
-  return when (user) {
-    is Admin -> "Admin"
-    is Pilot -> "Pilot"
-    is Crew -> "Crew"
-    else -> "Unknown"
-  }
-}
 
 // Composable function to display a card for a User object.
 @Composable
@@ -86,7 +76,7 @@ fun UserCard(user: User, onUserClick: (String) -> Unit) {
         horizontalArrangement = Arrangement.SpaceBetween) {
           Text(
               user.name(), fontWeight = FontWeight.Bold, style = MaterialTheme.typography.bodyLarge)
-          Text(displayMainRole(user))
+          Text(user.displayRoleName())
         }
   }
 }
@@ -210,8 +200,8 @@ fun UserManagementScreen(
         }
       },
   ) { padding ->
-    Column(modifier = Modifier.padding(padding)) {
-      TopBarTitle(defaultPadding)
+    Column(modifier = Modifier.padding(defaultPadding)) {
+      TopBanner("Users", lightOrange, padding)
       SearchBar(
           query = searchQuery,
           onQueryChanged = {

--- a/app/src/main/java/ch/epfl/skysync/screens/crewpilot/Home.kt
+++ b/app/src/main/java/ch/epfl/skysync/screens/crewpilot/Home.kt
@@ -10,8 +10,8 @@ import androidx.navigation.NavHostController
 import ch.epfl.skysync.components.FlightsList
 import ch.epfl.skysync.navigation.BottomBar
 import ch.epfl.skysync.navigation.Route
-import ch.epfl.skysync.ui.theme.HOME_SCREEN_TITLE
-import ch.epfl.skysync.ui.theme.Purple40
+import ch.epfl.skysync.ui.theme.ScreenTitles
+import ch.epfl.skysync.ui.theme.getThemeColor
 import ch.epfl.skysync.viewmodel.FlightsViewModel
 
 /** represents the home screen of the crew/pilot */
@@ -22,7 +22,7 @@ fun HomeScreen(navController: NavHostController, viewModel: FlightsViewModel) {
       modifier = Modifier.fillMaxSize(),
       bottomBar = { BottomBar(navController) },
   ) { padding ->
-    FlightsList(currentFlights, Purple40, padding, HOME_SCREEN_TITLE) { selectedFlight ->
+    FlightsList(currentFlights, getThemeColor(isAdmin = false), padding, ScreenTitles.HOME) { selectedFlight ->
       navController.navigate(Route.CREW_FLIGHT_DETAILS + "/${selectedFlight}")
     }
   }

--- a/app/src/main/java/ch/epfl/skysync/screens/crewpilot/Home.kt
+++ b/app/src/main/java/ch/epfl/skysync/screens/crewpilot/Home.kt
@@ -22,7 +22,8 @@ fun HomeScreen(navController: NavHostController, viewModel: FlightsViewModel) {
       modifier = Modifier.fillMaxSize(),
       bottomBar = { BottomBar(navController) },
   ) { padding ->
-    FlightsList(currentFlights, getThemeColor(isAdmin = false), padding, ScreenTitles.HOME) { selectedFlight ->
+    FlightsList(currentFlights, getThemeColor(isAdmin = false), padding, ScreenTitles.HOME) {
+        selectedFlight ->
       navController.navigate(Route.CREW_FLIGHT_DETAILS + "/${selectedFlight}")
     }
   }

--- a/app/src/main/java/ch/epfl/skysync/screens/crewpilot/Stats.kt
+++ b/app/src/main/java/ch/epfl/skysync/screens/crewpilot/Stats.kt
@@ -12,6 +12,7 @@ import ch.epfl.skysync.components.FlightsList
 import ch.epfl.skysync.navigation.BottomBar
 import ch.epfl.skysync.navigation.Route
 import ch.epfl.skysync.ui.theme.Purple40
+import ch.epfl.skysync.ui.theme.getThemeColor
 import ch.epfl.skysync.viewmodel.FinishedFlightsViewModel
 
 // Scaffold wrapper for the Stats Screen
@@ -24,7 +25,7 @@ fun StatsScreen(navController: NavHostController, viewModel: FinishedFlightsView
       floatingActionButton = {},
       floatingActionButtonPosition = FabPosition.End,
   ) { padding ->
-    FlightsList(finishedFlights, Purple40, padding, "Flights History") { selectedFlight ->
+    FlightsList(finishedFlights, getThemeColor(isAdmin = false), padding, "Flights History") { selectedFlight ->
       navController.navigate(Route.CREW_FLIGHT_DETAILS + "/${selectedFlight}")
     }
   }

--- a/app/src/main/java/ch/epfl/skysync/screens/crewpilot/Stats.kt
+++ b/app/src/main/java/ch/epfl/skysync/screens/crewpilot/Stats.kt
@@ -11,7 +11,6 @@ import androidx.navigation.NavHostController
 import ch.epfl.skysync.components.FlightsList
 import ch.epfl.skysync.navigation.BottomBar
 import ch.epfl.skysync.navigation.Route
-import ch.epfl.skysync.ui.theme.Purple40
 import ch.epfl.skysync.ui.theme.getThemeColor
 import ch.epfl.skysync.viewmodel.FinishedFlightsViewModel
 
@@ -25,7 +24,8 @@ fun StatsScreen(navController: NavHostController, viewModel: FinishedFlightsView
       floatingActionButton = {},
       floatingActionButtonPosition = FabPosition.End,
   ) { padding ->
-    FlightsList(finishedFlights, getThemeColor(isAdmin = false), padding, "Flights History") { selectedFlight ->
+    FlightsList(finishedFlights, getThemeColor(isAdmin = false), padding, "Flights History") {
+        selectedFlight ->
       navController.navigate(Route.CREW_FLIGHT_DETAILS + "/${selectedFlight}")
     }
   }

--- a/app/src/main/java/ch/epfl/skysync/ui/theme/Color.kt
+++ b/app/src/main/java/ch/epfl/skysync/ui/theme/Color.kt
@@ -35,3 +35,12 @@ val lightViolet = Color(0xFFE6E6FA)
 val lightPink = Color(0xFFF896FA)
 
 val cream = Color(0xFFffffeb)
+
+
+/**
+ * returns the theme color as a function of isAdmin
+ */
+fun getThemeColor(isAdmin: Boolean): Color {
+    return if (isAdmin) lightOrange
+    else Purple40
+}

--- a/app/src/main/java/ch/epfl/skysync/ui/theme/Color.kt
+++ b/app/src/main/java/ch/epfl/skysync/ui/theme/Color.kt
@@ -36,11 +36,7 @@ val lightPink = Color(0xFFF896FA)
 
 val cream = Color(0xFFffffeb)
 
-
-/**
- * returns the theme color as a function of isAdmin
- */
+/** returns the theme color as a function of isAdmin */
 fun getThemeColor(isAdmin: Boolean): Color {
-    return if (isAdmin) lightOrange
-    else Purple40
+  return if (isAdmin) lightOrange else Purple40
 }

--- a/app/src/main/java/ch/epfl/skysync/ui/theme/Titles.kt
+++ b/app/src/main/java/ch/epfl/skysync/ui/theme/Titles.kt
@@ -5,4 +5,9 @@ package ch.epfl.skysync.ui.theme
 /** Home screen */
 
 /** Title of the home screen */
-const val HOME_SCREEN_TITLE = "Upcoming flights"
+object ScreenTitles{
+    const val HOME = "Upcoming flights"
+    const val MESSAGES = "Messages"
+    const val HISTORY = "Flights History"
+}
+

--- a/app/src/main/java/ch/epfl/skysync/ui/theme/Titles.kt
+++ b/app/src/main/java/ch/epfl/skysync/ui/theme/Titles.kt
@@ -5,9 +5,8 @@ package ch.epfl.skysync.ui.theme
 /** Home screen */
 
 /** Title of the home screen */
-object ScreenTitles{
-    const val HOME = "Upcoming flights"
-    const val MESSAGES = "Messages"
-    const val HISTORY = "Flights History"
+object ScreenTitles {
+  const val HOME = "Upcoming flights"
+  const val MESSAGES = "Messages"
+  const val HISTORY = "Flights History"
 }
-


### PR DESCRIPTION
# modularized the TopBanner composable
After noticing code duplication for the top banners in the `UserManagement.kt `a generic banner composable was created and injected into all the screens 

# added title variables
Big titles are now stored and accessed in `ui.theme.Titles`


closes #462 